### PR TITLE
[7] feat: add TASKS section for Issue Spec task decomposition

### DIFF
--- a/agents/clarifier.md
+++ b/agents/clarifier.md
@@ -123,6 +123,10 @@ AC-N+1: [If hardware/physical verification is needed, describe the verification 
 ## BRANCH
 [PR target branch (optional — omit to use the project default)]
 
+## TASKS
+T{N}: [description] [create|modify|delete] file-path (depends: T{M} | none)
+(Optional section — see TASKS generation rules below)
+
 ## REFERENCES
 [Source type] URL or path — brief description (optional, but required if you looked up any sources)
 ```
@@ -139,6 +143,25 @@ AC-N+1: [If hardware/physical verification is needed, describe the verification 
 - Each line format: `[modify|create|delete] relative-path (reason)`
 - Only list files that definitely need changes — don't list files that "might" need changes
 - If the Coding Agent discovers during implementation that files outside SCOPE need changes, it will stop and ask the user
+
+**Rules for writing TASKS (## TASKS section):**
+- When SCOPE contains 3 or more entries, generate a `## TASKS` section to decompose the implementation into ordered tasks
+- When SCOPE contains fewer than 3 entries, do NOT generate a TASKS section (the issue is small enough for single-pass implementation)
+- Each task touches at most 3 files — if a task needs more than 3 files, split it into smaller tasks
+- Format: `T{N}: [description] [create|modify|delete] file-path (depends: T{M}, T{K} | none)`
+  - `T{N}:` — task ID, incrementing from T1
+  - `[P]` — optional parallel marker, placed after the colon and before the description; indicates the task can run in parallel with its dependencies' successors
+  - `[create|modify|delete] file-path` — file action brackets (same keywords as SCOPE), can appear multiple times for multi-file tasks
+  - `(depends: T{M}, T{K})` — explicit dependency list at the end; use `(depends: none)` for tasks with no dependencies
+- Every file path in TASKS must also appear in a SCOPE entry — no undeclared files
+- Task ordering should respect logical dependencies: data structures before logic, logic before tests
+- Example:
+  ```
+  ## TASKS
+  T1: Add TaskEntry struct [modify] internal/tracker/issuespec.go (depends: none)
+  T2: [P] Add parsing tests [modify] internal/tracker/issuespec_test.go (depends: T1)
+  T3: Update coding prompt [modify] internal/prompt/coding.go (depends: T1)
+  ```
 
 ## Rules
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -97,6 +97,20 @@ If PR comments contain a previous review report (i.e., this is a revision review
 - Spot-check for regressions in existing ACs, but do NOT re-review the entire implementation from scratch
 - Use the Revision Review Report format: list each previous MUST FIX item and mark as ✅ Fixed / ❌ Still open
 
+## Task-Commit Verification
+
+When the Issue Spec contains a `## TASKS` section, verify that each task ID (T1, T2, ...) appears in a commit message in the PR.
+
+1. Read the Issue Spec's `## TASKS` section to collect all task IDs
+2. Use `git log --oneline` to list all commits in the PR
+3. For each task ID, check that at least one commit message contains that task ID (e.g., `[ISSUE-ID] T1: ...`)
+4. Report missing task commits in the Review Report under a new **Task-Commit Check** subsection:
+   - T1: ✅ Found in commit abc1234
+   - T2: ❌ No matching commit found
+5. If any task ID is missing from commits, add it as a 🔴 MUST FIX finding
+
+If the Issue Spec does NOT contain a `## TASKS` section, skip this check entirely.
+
 ## Review Integrity
 
 - You are a critic, not a cheerleader. Omit praise ("well done", "clean code", "nice approach") — only report findings.

--- a/internal/prompt/coding.go
+++ b/internal/prompt/coding.go
@@ -49,7 +49,18 @@ func BuildCodingPrompt(p CodingParams) string {
 
 	fmt.Fprintf(&b, "\n\n## Logging Policy\n\n%s", logPolicyText(p.LogPolicy))
 
-	fmt.Fprintf(&b, `
+	if len(p.Spec.Tasks) > 0 {
+		buildTaskWorkflow(&b, p)
+	} else {
+		buildStandardWorkflow(&b, p)
+	}
+
+	return b.String()
+}
+
+// buildStandardWorkflow writes the default coding workflow (no TASKS decomposition).
+func buildStandardWorkflow(b *strings.Builder, p CodingParams) {
+	fmt.Fprintf(b, `
 
 ## Your Workflow
 
@@ -87,8 +98,70 @@ Prefer MCP tools — pass content directly as a parameter.
 If MCP is unavailable, use Bash heredoc to write to a temp file, then curl with @file.
 Never embed long text directly in bash commands.
 `, p.IssueID, p.BaseBranch, p.BaseBranch)
+}
 
-	return b.String()
+// buildTaskWorkflow writes the task-ordered coding workflow when TASKS is present.
+func buildTaskWorkflow(b *strings.Builder, p CodingParams) {
+	b.WriteString("\n\n## Task Decomposition\n\n")
+	b.WriteString("This issue has been decomposed into ordered tasks. Execute tasks in order.\n")
+	b.WriteString("Commit after each task with format: [" + p.IssueID + "] T{N}: {short description}\n\n")
+	for _, task := range p.Spec.Tasks {
+		fmt.Fprintf(b, "- %s: ", task.ID)
+		if task.Parallel {
+			b.WriteString("[P] ")
+		}
+		b.WriteString(task.Description)
+		if len(task.Paths) > 0 {
+			b.WriteString(" — files: " + strings.Join(task.Paths, ", "))
+		}
+		if len(task.DependsOn) > 0 {
+			b.WriteString(" (depends: " + strings.Join(task.DependsOn, ", ") + ")")
+		}
+		b.WriteByte('\n')
+	}
+
+	fmt.Fprintf(b, `
+## Your Workflow
+
+Execute tasks in order. Commit after each task.
+
+1. Read CLAUDE.md to understand the project's architecture principles and logging policy
+   Read .claude/docs/tracker.md to understand how to operate the tracker (open PR, update status)
+   Read .claude/docs/agent-guidelines.md to understand the behavioral rules for AI agents
+   Read .claude/docs/code-construction-principles.md to understand the code quality baseline
+2. Read all files listed in SCOPE to understand the existing code structure
+3. If references list any reference files, read those too
+4. If implementation depends on external libraries or APIs not fully documented in REFERENCES, use WebSearch to verify current API signatures and version compatibility before coding — do not code against training-data assumptions
+5. Before starting implementation, update issue label: remove "todo", add "wip"
+6. For each task (T1, T2, ...):
+   a. Implement the task according to APPROACH
+   b. During implementation, ensure all new code follows the logging policy in CLAUDE.md and the code quality baseline
+   c. After completing the task, re-read modified files to verify consistency
+   d. Verify relevant ACs that relate to this task
+   e. Commit with format: [%s] T{N}: {short description}
+   f. If the task fails (tests break, build error), retry once. If still failing, stop and post issue comment explaining what failed — do NOT open PR
+7. After all tasks complete, self-check against each ACCEPTANCE_CRITERIA item
+8. Use git add + git commit for any final adjustments
+9. When opening a PR, you **must** target the `+"`%s`"+` branch (--base %s).
+   Targeting any other branch is strictly forbidden. If unsure, stop and confirm before opening the PR.
+10. After opening the PR, update issue label: remove "wip", add "review"
+
+## When to Stop and Ask the User
+
+- The APPROACH description is unclear and you are unsure how to proceed
+- You find that you need to modify files outside the SCOPE
+- You find that a CONSTRAINT conflicts with the APPROACH
+- You encounter an uncertain technical decision (multiple valid approaches)
+- Any hardware-related logic you are unsure about (timeout values, safe-state behavior, etc.)
+- You discover during implementation that the APPROACH has a flaw or gap not covered by the Issue Spec
+
+## Tracker Operation Notes
+
+When opening a PR or updating status, follow the instructions in .claude/docs/tracker.md.
+Prefer MCP tools — pass content directly as a parameter.
+If MCP is unavailable, use Bash heredoc to write to a temp file, then curl with @file.
+Never embed long text directly in bash commands.
+`, p.IssueID, p.BaseBranch, p.BaseBranch)
 }
 
 func logPolicyText(policy string) string {

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -257,6 +257,64 @@ func TestBuildRevisionPrompt_AllSections(t *testing.T) {
 	}
 }
 
+func testSpecWithTasks() *tracker.IssueSpec {
+	spec := testSpec()
+	spec.Tasks = []tracker.TaskEntry{
+		{ID: "T1", Description: "Add retry logic", Paths: []string{"src/EtherCatService.cs"}, DependsOn: nil},
+		{ID: "T2", Description: "Add retry policy", Parallel: true, Paths: []string{"src/RetryPolicy.cs"}, DependsOn: []string{"T1"}},
+	}
+	return spec
+}
+
+func TestBuildCodingPrompt_WithTasks(t *testing.T) {
+	p := CodingParams{
+		IssueID:    "ASE-47",
+		IssueTitle: "EtherCAT reconnect backoff",
+		Spec:       testSpecWithTasks(),
+		LogPolicy:  "strict",
+		BaseBranch: "dev",
+	}
+
+	result := BuildCodingPrompt(p)
+
+	mustContain := []string{
+		"Execute tasks in order",
+		"Commit after each task",
+		"[ASE-47] T{N}:",
+		"T1:",
+		"T2:",
+		"re-read modified files",
+		"Verify relevant ACs",
+		"retry once",
+		"stop and post issue comment",
+		"do NOT open PR",
+	}
+	for _, c := range mustContain {
+		if !strings.Contains(result, c) {
+			t.Errorf("task prompt missing %q", c)
+		}
+	}
+}
+
+func TestBuildCodingPrompt_WithoutTasks_NoTaskWorkflow(t *testing.T) {
+	p := CodingParams{
+		IssueID:    "ASE-48",
+		IssueTitle: "simple change",
+		Spec:       testSpec(), // no Tasks
+		LogPolicy:  "minimal",
+		BaseBranch: "dev",
+	}
+
+	result := BuildCodingPrompt(p)
+
+	if strings.Contains(result, "Execute tasks in order") {
+		t.Error("prompt without tasks should NOT contain 'Execute tasks in order'")
+	}
+	if strings.Contains(result, "Task Decomposition") {
+		t.Error("prompt without tasks should NOT contain 'Task Decomposition'")
+	}
+}
+
 func TestBuildReviewerPrompt_BaseBranch(t *testing.T) {
 	result := BuildReviewerPrompt(ReviewerParams{
 		IssueID:    "TEST-1",

--- a/internal/tracker/issuespec.go
+++ b/internal/tracker/issuespec.go
@@ -20,6 +20,15 @@ var validScopeActions = []string{"modify", "create", "delete"}
 // vagueWords lists forbidden vague words/phrases in acceptance criteria.
 var vagueWords = []string{"appropriate", "reasonable", "sufficient", "when necessary"}
 
+// TaskEntry represents a single task line in the ## TASKS section.
+type TaskEntry struct {
+	ID          string   // e.g. "T1", "T2"
+	Description string   // task description text
+	Parallel    bool     // true if [P] marker is present
+	Paths       []string // file paths extracted from [create], [modify], [delete] actions
+	DependsOn   []string // task IDs this task depends on; empty if (depends: none)
+}
+
 // IssueSpec is the structured representation of an issue body.
 type IssueSpec struct {
 	Context            string
@@ -29,6 +38,7 @@ type IssueSpec struct {
 	Constraints        string
 	References         string // optional section
 	Branch             string // optional: PR target branch (from ## BRANCH section)
+	Tasks              []TaskEntry // optional: task decomposition from ## TASKS section
 }
 
 // ScopeEntry represents a single file scope line.
@@ -76,6 +86,9 @@ func ValidateIssueSpec(body string) ValidationResult {
 
 	// Check SCOPE-AC coverage
 	checkScopeACCoverage(body, &result)
+
+	// Check TASKS-SCOPE cross-validation
+	checkTasksScopeCoverage(body, &result)
 
 	return result
 }
@@ -309,6 +322,16 @@ func ParseIssueSpec(body string) (*IssueSpec, error) {
 		}
 	}
 
+	// Parse TASKS entries (optional section)
+	if tasksContent, ok := sections["TASKS"]; ok && tasksContent != "" {
+		for _, line := range strings.Split(tasksContent, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if entry, ok := parseTaskEntry(trimmed); ok {
+				spec.Tasks = append(spec.Tasks, entry)
+			}
+		}
+	}
+
 	return spec, nil
 }
 
@@ -341,6 +364,168 @@ func splitBySections(body string) map[string]string {
 	}
 
 	return sections
+}
+
+// checkTasksScopeCoverage warns when a TASKS entry references a file path
+// not found in any SCOPE entry.
+func checkTasksScopeCoverage(body string, result *ValidationResult) {
+	sections := splitBySections(body)
+	tasksContent, ok := sections["TASKS"]
+	if !ok || tasksContent == "" {
+		return
+	}
+	scopeContent := sections["SCOPE"]
+	if scopeContent == "" {
+		return
+	}
+
+	// Collect all SCOPE file paths
+	scopePaths := make(map[string]bool)
+	for _, line := range strings.Split(scopeContent, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			entry := parseScopeEntry(trimmed)
+			if entry.Path != "" {
+				scopePaths[entry.Path] = true
+			}
+		}
+	}
+
+	// Check each task's paths against SCOPE
+	for _, line := range strings.Split(tasksContent, "\n") {
+		trimmed := strings.TrimSpace(line)
+		entry, ok := parseTaskEntry(trimmed)
+		if !ok {
+			continue
+		}
+		for _, p := range entry.Paths {
+			if !scopePaths[p] {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("TASKS entry %s references file %s not found in SCOPE", entry.ID, p))
+			}
+		}
+	}
+}
+
+// parseTaskEntry parses a task line like:
+// T1: Add TaskEntry struct [modify] issuespec.go (depends: none)
+// T2: [P] Update prompt [modify] coding.go [modify] common.go (depends: T1)
+// Returns the parsed entry and true if the line is a valid task line.
+func parseTaskEntry(line string) (TaskEntry, bool) {
+	// Task lines start with T followed by a number and a colon
+	if !strings.HasPrefix(line, "T") {
+		return TaskEntry{}, false
+	}
+
+	// Extract ID (e.g., "T1", "T12")
+	colonIdx := strings.Index(line, ":")
+	if colonIdx < 2 {
+		return TaskEntry{}, false
+	}
+	id := line[:colonIdx]
+	// Validate ID is T followed by digits
+	numPart := id[1:]
+	if _, err := strconv.Atoi(numPart); err != nil {
+		return TaskEntry{}, false
+	}
+
+	rest := strings.TrimSpace(line[colonIdx+1:])
+
+	entry := TaskEntry{ID: id}
+
+	// Check for [P] parallel marker at the start of rest
+	if strings.HasPrefix(rest, "[P]") {
+		entry.Parallel = true
+		rest = strings.TrimSpace(rest[3:])
+	}
+
+	// Extract (depends: ...) from the end
+	if depStart := strings.LastIndex(rest, "(depends:"); depStart >= 0 {
+		depSection := rest[depStart:]
+		rest = strings.TrimSpace(rest[:depStart])
+
+		// Extract the content between "depends:" and ")"
+		depContent := strings.TrimPrefix(depSection, "(depends:")
+		depContent = strings.TrimSuffix(strings.TrimSpace(depContent), ")")
+		depContent = strings.TrimSpace(depContent)
+
+		if depContent != "none" && depContent != "" {
+			for _, dep := range strings.Split(depContent, ",") {
+				dep = strings.TrimSpace(dep)
+				if dep != "" {
+					entry.DependsOn = append(entry.DependsOn, dep)
+				}
+			}
+		}
+	}
+
+	// Extract file paths from bracket patterns: [create], [modify], [delete]
+	// and collect the description (everything that's not a file action)
+	var descParts []string
+	remaining := rest
+	for remaining != "" {
+		bracketIdx := strings.Index(remaining, "[")
+		if bracketIdx < 0 {
+			// No more brackets — rest is description
+			if part := strings.TrimSpace(remaining); part != "" {
+				descParts = append(descParts, part)
+			}
+			break
+		}
+
+		// Text before the bracket is description
+		if bracketIdx > 0 {
+			if part := strings.TrimSpace(remaining[:bracketIdx]); part != "" {
+				descParts = append(descParts, part)
+			}
+		}
+
+		closeBracket := strings.Index(remaining[bracketIdx:], "]")
+		if closeBracket < 0 {
+			// Malformed bracket — treat rest as description
+			if part := strings.TrimSpace(remaining[bracketIdx:]); part != "" {
+				descParts = append(descParts, part)
+			}
+			break
+		}
+		closeBracket += bracketIdx
+
+		action := strings.ToLower(remaining[bracketIdx+1 : closeBracket])
+		isFileAction := false
+		for _, valid := range validScopeActions {
+			if action == valid {
+				isFileAction = true
+				break
+			}
+		}
+
+		if isFileAction {
+			// Extract the file path (next whitespace-delimited token)
+			afterAction := strings.TrimSpace(remaining[closeBracket+1:])
+			spaceIdx := strings.IndexAny(afterAction, " \t")
+			var filePath string
+			if spaceIdx >= 0 {
+				filePath = afterAction[:spaceIdx]
+				remaining = afterAction[spaceIdx:]
+			} else {
+				filePath = afterAction
+				remaining = ""
+			}
+			if filePath != "" {
+				entry.Paths = append(entry.Paths, filePath)
+			}
+		} else {
+			// Not a file action bracket — treat as description
+			if part := strings.TrimSpace(remaining[bracketIdx : closeBracket+1]); part != "" {
+				descParts = append(descParts, part)
+			}
+			remaining = remaining[closeBracket+1:]
+		}
+	}
+
+	entry.Description = strings.Join(descParts, " ")
+
+	return entry, true
 }
 
 // parseScopeEntry parses a line like "[modify] path/to/file (reason)".

--- a/internal/tracker/issuespec_test.go
+++ b/internal/tracker/issuespec_test.go
@@ -31,6 +31,31 @@ dev
 [官方文件] https://example.com — EtherCAT 文件
 `
 
+const fullIssueBodyWithTasks = `## CONTEXT
+Large implementation requiring task decomposition.
+
+## APPROACH
+Implement in ordered tasks for reliability.
+
+## ACCEPTANCE_CRITERIA
+AC-1: TaskEntry struct exists in issuespec.go
+AC-2: IssueSpec has Tasks field
+AC-3: coding.go includes task workflow
+
+## SCOPE
+[modify] internal/tracker/issuespec.go (add TaskEntry struct)
+[modify] internal/tracker/issuespec_test.go (add tests)
+[modify] internal/prompt/coding.go (task workflow)
+
+## CONSTRAINTS
+No new libraries
+
+## TASKS
+T1: Add TaskEntry struct and parsing [modify] internal/tracker/issuespec.go (depends: none)
+T2: [P] Add tests for task parsing [modify] internal/tracker/issuespec_test.go (depends: T1)
+T3: Update coding prompt with task workflow [modify] internal/prompt/coding.go (depends: T1, T2)
+`
+
 func TestValidateIssueSpec_AllPresent(t *testing.T) {
 	result := ValidateIssueSpec(fullIssueBody)
 	if len(result.Errors) != 0 {
@@ -406,6 +431,163 @@ func TestValidateIssueSpec_NoFalsePositiveOnUnresolvedIssue(t *testing.T) {
 	for _, e := range result.Errors {
 		if strings.Contains(e, "UNRESOLVED") {
 			t.Errorf("false positive: [UNRESOLVED_ISSUE] should not trigger UNRESOLVED error, got: %q", e)
+		}
+	}
+}
+
+// --- TASKS parsing tests ---
+
+func TestParseIssueSpec_TasksParsing_FullBody(t *testing.T) {
+	spec, err := ParseIssueSpec(fullIssueBodyWithTasks)
+	if err != nil {
+		t.Fatalf("ParseIssueSpec failed: %v", err)
+	}
+	if len(spec.Tasks) != 3 {
+		t.Fatalf("expected 3 tasks, got %d", len(spec.Tasks))
+	}
+
+	// T1: sequential, one path, depends: none
+	if spec.Tasks[0].ID != "T1" {
+		t.Errorf("Tasks[0].ID = %q, want T1", spec.Tasks[0].ID)
+	}
+	if spec.Tasks[0].Parallel {
+		t.Error("Tasks[0].Parallel should be false")
+	}
+	if len(spec.Tasks[0].Paths) != 1 || spec.Tasks[0].Paths[0] != "internal/tracker/issuespec.go" {
+		t.Errorf("Tasks[0].Paths = %v, want [internal/tracker/issuespec.go]", spec.Tasks[0].Paths)
+	}
+	if len(spec.Tasks[0].DependsOn) != 0 {
+		t.Errorf("Tasks[0].DependsOn = %v, want empty", spec.Tasks[0].DependsOn)
+	}
+
+	// T2: parallel, one path, depends: T1
+	if spec.Tasks[1].ID != "T2" {
+		t.Errorf("Tasks[1].ID = %q, want T2", spec.Tasks[1].ID)
+	}
+	if !spec.Tasks[1].Parallel {
+		t.Error("Tasks[1].Parallel should be true")
+	}
+
+	// T3: sequential, one path, depends: T1, T2
+	if spec.Tasks[2].ID != "T3" {
+		t.Errorf("Tasks[2].ID = %q, want T3", spec.Tasks[2].ID)
+	}
+}
+
+func TestParseIssueSpec_TasksAbsent_Nil(t *testing.T) {
+	spec, err := ParseIssueSpec(fullIssueBody)
+	if err != nil {
+		t.Fatalf("ParseIssueSpec failed: %v", err)
+	}
+	if spec.Tasks != nil {
+		t.Errorf("expected nil Tasks when ## TASKS absent, got %v", spec.Tasks)
+	}
+}
+
+func TestParseTaskEntry_ParallelFlag(t *testing.T) {
+	line := "T2: [P] Update prompt generation [modify] coding.go (depends: T1)"
+	entry, ok := parseTaskEntry(line)
+	if !ok {
+		t.Fatal("parseTaskEntry returned false for valid line")
+	}
+	if entry.ID != "T2" {
+		t.Errorf("ID = %q, want T2", entry.ID)
+	}
+	if !entry.Parallel {
+		t.Error("Parallel should be true")
+	}
+	if len(entry.Paths) != 1 || entry.Paths[0] != "coding.go" {
+		t.Errorf("Paths = %v, want [coding.go]", entry.Paths)
+	}
+	if len(entry.DependsOn) != 1 || entry.DependsOn[0] != "T1" {
+		t.Errorf("DependsOn = %v, want [T1]", entry.DependsOn)
+	}
+}
+
+func TestParseTaskEntry_MultipleDependencies(t *testing.T) {
+	line := "T3: Integrate changes [modify] main.go (depends: T1, T2)"
+	entry, ok := parseTaskEntry(line)
+	if !ok {
+		t.Fatal("parseTaskEntry returned false")
+	}
+	if entry.ID != "T3" {
+		t.Errorf("ID = %q, want T3", entry.ID)
+	}
+	if len(entry.DependsOn) != 2 {
+		t.Fatalf("DependsOn length = %d, want 2", len(entry.DependsOn))
+	}
+	if entry.DependsOn[0] != "T1" || entry.DependsOn[1] != "T2" {
+		t.Errorf("DependsOn = %v, want [T1 T2]", entry.DependsOn)
+	}
+}
+
+func TestParseTaskEntry_DependsNone(t *testing.T) {
+	line := "T1: Initial setup [create] newfile.go (depends: none)"
+	entry, ok := parseTaskEntry(line)
+	if !ok {
+		t.Fatal("parseTaskEntry returned false")
+	}
+	if len(entry.DependsOn) != 0 {
+		t.Errorf("DependsOn = %v, want empty slice (not containing 'none')", entry.DependsOn)
+	}
+}
+
+func TestParseTaskEntry_MultipleFileActions(t *testing.T) {
+	line := "T2: [P] Update both files [create] x.go [modify] y.go (depends: T1)"
+	entry, ok := parseTaskEntry(line)
+	if !ok {
+		t.Fatal("parseTaskEntry returned false")
+	}
+	if len(entry.Paths) != 2 {
+		t.Fatalf("Paths length = %d, want 2", len(entry.Paths))
+	}
+	if entry.Paths[0] != "x.go" || entry.Paths[1] != "y.go" {
+		t.Errorf("Paths = %v, want [x.go y.go]", entry.Paths)
+	}
+	if !entry.Parallel {
+		t.Error("Parallel should be true")
+	}
+	if len(entry.DependsOn) != 1 || entry.DependsOn[0] != "T1" {
+		t.Errorf("DependsOn = %v, want [T1]", entry.DependsOn)
+	}
+}
+
+func TestValidateIssueSpec_TasksScopeCrossValidation(t *testing.T) {
+	body := `## CONTEXT
+ctx
+
+## APPROACH
+approach
+
+## ACCEPTANCE_CRITERIA
+AC-1: test issuespec.go changes
+
+## SCOPE
+[modify] internal/tracker/issuespec.go (reason)
+
+## CONSTRAINTS
+none
+
+## TASKS
+T1: Update spec [modify] internal/tracker/issuespec.go (depends: none)
+T2: Update unknown file [modify] unknown/file.go (depends: T1)
+`
+	result := ValidateIssueSpec(body)
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "T2") && strings.Contains(w, "unknown/file.go") && strings.Contains(w, "not found in SCOPE") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about T2 referencing unknown/file.go not in SCOPE, got warnings: %v", result.Warnings)
+	}
+
+	// T1's path IS in SCOPE — should NOT produce a warning for it
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "T1") && strings.Contains(w, "issuespec.go") && strings.Contains(w, "not found in SCOPE") {
+			t.Errorf("unexpected warning for T1's valid SCOPE path: %q", w)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `TaskEntry` struct and `Tasks []TaskEntry` field to `IssueSpec` for optional `## TASKS` section parsing
- Implement `parseTaskEntry()` that extracts task ID, `[P]` parallel marker, file action paths (`[create]`/`[modify]`/`[delete]`), and `(depends: ...)` syntax — reusing existing `splitBySections` infrastructure
- Add TASKS-SCOPE cross-validation warning in `ValidateIssueSpec` when a task references a file not in SCOPE
- Add conditional task-ordered workflow injection in `BuildCodingPrompt` — when Tasks is non-empty, generates per-task commit instructions with retry-once and stop-on-failure semantics
- Update `agents/clarifier.md` with TASKS generation rules (threshold: SCOPE >= 3 entries, max 3 files per task, format documentation)
- Update `agents/reviewer.md` with task-commit verification step (each task ID must appear in a commit message)
- Zero regression on existing tests; 7 new tests in `issuespec_test.go`, 2 new tests in `prompt_test.go`

## Test plan

- [x] `go test ./internal/tracker/...` — all 68 tests pass (including 7 new TASKS tests)
- [x] `go test ./internal/prompt/...` — all 11 tests pass (including 2 new task workflow tests)
- [x] `go build ./...` — compiles cleanly
- [ ] Verify existing tests have zero regressions
- [ ] Review clarifier.md TASKS rules for completeness
- [ ] Review reviewer.md task-commit verification step

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)