### PR TITLE
[55] Add --channel-enabled flag to Enter key launches

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1034,6 +1034,14 @@ func (m Model) launchFocusClaudeCmd(slotKey string) (tea.Model, tea.Cmd) {
 	}
 	wtPath := slot.WorktreePath
 	issueID := slot.IssueID
+	// Find project config to check channel_enabled (within existing RLock).
+	var channelEnabled bool
+	for i := range m.state.projects {
+		if m.state.projects[i].ID == m.focusProjectID {
+			channelEnabled = m.state.projects[i].ChannelEnabled
+			break
+		}
+	}
 	m.state.RUnlock()
 
 	if _, err := os.Stat(wtPath); err != nil {
@@ -1048,7 +1056,11 @@ func (m Model) launchFocusClaudeCmd(slotKey string) (tea.Model, tea.Cmd) {
 	focusProjectID := m.focusProjectID
 
 	return m, func() tea.Msg {
-		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg)
+		var args []string
+		if channelEnabled {
+			args = append(args, "--channel-enabled")
+		}
+		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg, args...)
 		return LaunchResultMsg{
 			ProjectID:   focusProjectID,
 			TrackingKey: trackingKey,
@@ -1267,8 +1279,33 @@ func (m Model) handleAgentEvent(msg AgentEventMsg) (tea.Model, tea.Cmd) {
 func (m Model) launchClaudeCmd() tea.Cmd {
 	project := m.state.projects[m.cursor]
 	cfg := m.state.cfg.Terminal
+	projectPath := platform.ResolvePath(project.Path.Windows, project.Path.WSL)
+	logger := m.state.logger
+
+	// Capture broker info for .mcp.json (read-only after init).
+	channelEnabled := project.ChannelEnabled
+	channelListen := project.ChannelListen
+	var brokerAddr string
+	if channelEnabled && m.state.broker != nil {
+		brokerAddr = m.state.broker.Addr()
+	}
+	zpitBin := m.state.cfg.ZpitBin
+
 	return func() tea.Msg {
-		result, err := terminal.LaunchClaude(project, cfg)
+		// Write .mcp.json for channel communication (Enter launch uses issue_id "0" = lobby).
+		if channelEnabled && brokerAddr != "" {
+			if err := writeMCPConfig(projectPath, brokerAddr, project.ID, "0", zpitBin, channelListen); err != nil {
+				logger.Printf("enter: failed to write .mcp.json for project=%s: %v", project.ID, err)
+			} else {
+				logger.Printf("enter: wrote .mcp.json to %s for project=%s", projectPath, project.ID)
+			}
+		}
+
+		var args []string
+		if channelEnabled {
+			args = append(args, "--channel-enabled")
+		}
+		result, err := terminal.LaunchClaude(project, cfg, args...)
 		return LaunchResultMsg{
 			ProjectID: project.ID,
 			Result:    result,


### PR DESCRIPTION
## Summary
- `launchClaudeCmd()` (project list Enter): writes `.mcp.json` when `channelEnabled && brokerAddr != ""`, passes `--channel-enabled` to `terminal.LaunchClaude()`, logs write result
- `launchFocusClaudeCmd()` (loop slot Enter): looks up project config within existing `RLock` section, passes `--channel-enabled` to `terminal.LaunchClaudeInDir()`
- When `channel_enabled == false`, both functions behave identically to before (no flag, no `.mcp.json`)

Closes #55

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 15 packages)
- [ ] Manual: set `channel_enabled = true` on a project, press Enter on project list → verify `.mcp.json` written to project root and `--dangerously-load-development-channels server:zpit-channel` appears in launched command
- [ ] Manual: in loop focus view, press Enter on a slot → verify `--dangerously-load-development-channels` appears in launched command
- [ ] Manual: set `channel_enabled = false`, press Enter → verify no `.mcp.json` written and no extra flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
