### PR TITLE
feat: add terminal focus panel and kill terminal via Tab + x key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ The TUI follows Bubble Tea's Elm architecture with a consistent pattern across a
 
 Loop engine example: `loopPollCmd` (cmd) → `LoopPollMsg` (msg) → handler creates worktree cmd → `LoopWorktreeCreatedMsg` → handler launches agent → `LoopAgentLaunchedMsg` → handler starts label polling → `LoopLabelPollMsg` → handler detects "review" label → launches reviewer...
 
+**Focus panel system**: The main view (`ViewProjects`) has three focusable panels controlled by `FocusedPanel` enum (`FocusProjects` → `FocusTerminals` → `FocusLoopSlots`). Tab cycles through panels that have content (terminals panel skipped if no active terminals, loop panel skipped if no loop slots). Each panel has its own cursor (`cursor` for projects, `termCursor` for terminals, `loopSlotCursor` for loop slots). The `x` key kills the selected terminal when `FocusTerminals` is active (with confirm dialog, force-kills the process). `FocusedPanel` is per-Model (per-connection UI state), not shared in AppState.
+
 ### Session Log Monitoring
 
 The TUI monitors Claude Code sessions via JSONL log files:

--- a/docs/architecture/02-tui-design.md
+++ b/docs/architecture/02-tui-design.md
@@ -25,15 +25,16 @@
 ║  🌐  個人品牌網頁                   [u] Undeploy 部署檔案           ║
 ║     Astro    │ 5 todo │ 0 進行中                                  ║
 ║                                    ──────────────────────          ║
-║  🖥️  報警管理工具                   [a] 新增專案                    ║
-║     WPF      │ 0 todo │ 0 進行中   [e] 編輯設定 (子選單)            ║
+║  🖥️  報警管理工具                   [x] 關閉終端                    ║
+║     WPF      │ 0 todo │ 0 進行中   [a] 新增專案                    ║
+║                                    [e] 編輯設定 (子選單)            ║
 ║                                    [?] 說明                       ║
 ║ ›📱  Android 監控 App               [q] 離開                       ║
 ║     Kotlin   │ 2 todo │ 0 進行中                                  ║
 ║                                                                    ║
 ╠══════════════════════════════════════════════════════════════════════╣
-║  活躍終端                                                          ║
-║  [1] ASE 檢測  │ 🟢 實作中: EtherCAT reconnect backoff │ 02:15    ║
+║  活躍終端 (Tab 切換至此區域，↑↓ 選擇，x 關閉終端)                  ║
+║ ›[1] ASE 檢測  │ 🟢 實作中: EtherCAT reconnect backoff │ 02:15    ║
 ║      切換: tmux select-window -t ase-inspection                    ║
 ║  [2] 個人網頁  │ 🟢 AI Review 完成，等待你確認 PR                  ║
 ║      切換: tmux select-window -t personal-site                     ║
@@ -51,7 +52,9 @@
 - 快捷鍵 [c][l][r][s]：同樣在新終端啟動對應的 agent
 - [u]：移除 Zpit 部署到專案的 agents/docs/hooks 檔案
 - [f]：啟動效率 Agent（輕量模式，無 hooks、無 tracker、self-review）
-- 「活躍終端」區域：即時顯示正在運行的 Claude Code session 狀態
+- Tab：三面板循環切換 — 專案列表 → 活躍終端（有終端時）→ Loop 狀態（有 slot 時）→ 專案列表
+- [x]：當焦點在活躍終端時，關閉選中的終端（force kill process，需確認）
+- 「活躍終端」區域：即時顯示正在運行的 Claude Code session 狀態，支援 cursor 選擇和 x 鍵關閉
   （資料來源：Claude Code session log + JSONL 解析）
 - 「最近活動」區域：**尚未實作** — 設計上從 session log 解析 agent 的具體操作
 

--- a/internal/locale/en.go
+++ b/internal/locale/en.go
@@ -87,6 +87,8 @@ var en = map[Key]string{
 	// Terminal focus panel
 	KeyKillTerminal:         "Terminal killed: %s (PID %d)",
 	KeyKillTerminalConfirm:  "Kill terminal %s (PID %d)?\nThis will force-terminate the Claude Code process.",
+	KeyKillFailed:           "Kill failed: %s",
+	KeyKillButton:           "Kill",
 	KeyTerminalNoPID:        "Terminal has no active process",
 	KeyTerminalAlreadyEnded: "Terminal already ended",
 	KeySwitchPanel:          "Switch Panel",

--- a/internal/locale/en.go
+++ b/internal/locale/en.go
@@ -84,6 +84,15 @@ var en = map[Key]string{
 	KeyNoWorktreePath: "Slot has no worktree",
 	KeyLoopSlotHelp:   "Enter: open Claude  o: open folder  p: open issue  \u2191\u2193: navigate  Tab/Esc: back",
 
+	// Terminal focus panel
+	KeyKillTerminal:         "Terminal killed: %s (PID %d)",
+	KeyKillTerminalConfirm:  "Kill terminal %s (PID %d)?\nThis will force-terminate the Claude Code process.",
+	KeyTerminalNoPID:        "Terminal has no active process",
+	KeyTerminalAlreadyEnded: "Terminal already ended",
+	KeySwitchPanel:          "Switch Panel",
+	KeyTerminalHelp:         "\u2191\u2193 select \u2502 x close \u2502 Tab switch \u2502 Esc back",
+	KeyCloseTerminal:        "Close Terminal",
+
 	// Sound file warning
 	KeySoundFileNotFound: "Sound file not found: %s",
 

--- a/internal/locale/keys.go
+++ b/internal/locale/keys.go
@@ -85,6 +85,15 @@ const (
 	KeyNoWorktreePath Key = "no_worktree_path"
 	KeyLoopSlotHelp   Key = "loop_slot_help"
 
+	// Terminal focus panel
+	KeyKillTerminal         Key = "kill_terminal"
+	KeyKillTerminalConfirm  Key = "kill_terminal_confirm"
+	KeyTerminalNoPID        Key = "terminal_no_pid"
+	KeyTerminalAlreadyEnded Key = "terminal_already_ended"
+	KeySwitchPanel          Key = "switch_panel"
+	KeyTerminalHelp         Key = "terminal_help"
+	KeyCloseTerminal        Key = "close_terminal"
+
 	// Channel view
 	KeyChannelTitle          Key = "channel_title"
 	KeyChannelNoActivity     Key = "channel_no_activity"

--- a/internal/locale/keys.go
+++ b/internal/locale/keys.go
@@ -88,6 +88,8 @@ const (
 	// Terminal focus panel
 	KeyKillTerminal         Key = "kill_terminal"
 	KeyKillTerminalConfirm  Key = "kill_terminal_confirm"
+	KeyKillFailed           Key = "kill_failed"
+	KeyKillButton           Key = "kill_button"
 	KeyTerminalNoPID        Key = "terminal_no_pid"
 	KeyTerminalAlreadyEnded Key = "terminal_already_ended"
 	KeySwitchPanel          Key = "switch_panel"

--- a/internal/locale/zh_tw.go
+++ b/internal/locale/zh_tw.go
@@ -87,6 +87,8 @@ var zhTW = map[Key]string{
 	// Terminal focus panel
 	KeyKillTerminal:         "終端已關閉：%s (PID %d)",
 	KeyKillTerminalConfirm:  "關閉終端 %s (PID %d)？\n這將強制終止 Claude Code 程序。",
+	KeyKillFailed:           "關閉失敗：%s",
+	KeyKillButton:           "關閉",
 	KeyTerminalNoPID:        "終端無有效程序",
 	KeyTerminalAlreadyEnded: "終端已結束",
 	KeySwitchPanel:          "切換面板",

--- a/internal/locale/zh_tw.go
+++ b/internal/locale/zh_tw.go
@@ -84,6 +84,15 @@ var zhTW = map[Key]string{
 	KeyNoWorktreePath: "Slot 無 worktree 路徑",
 	KeyLoopSlotHelp:   "Enter: 開啟 Claude  o: 開啟資料夾  p: 開啟 issue  \u2191\u2193: 選擇  Tab/Esc: 返回",
 
+	// Terminal focus panel
+	KeyKillTerminal:         "終端已關閉：%s (PID %d)",
+	KeyKillTerminalConfirm:  "關閉終端 %s (PID %d)？\n這將強制終止 Claude Code 程序。",
+	KeyTerminalNoPID:        "終端無有效程序",
+	KeyTerminalAlreadyEnded: "終端已結束",
+	KeySwitchPanel:          "切換面板",
+	KeyTerminalHelp:         "\u2191\u2193 選擇 \u2502 x 關閉 \u2502 Tab 切換 \u2502 Esc 返回",
+	KeyCloseTerminal:        "關閉終端",
+
 	// Sound file warning
 	KeySoundFileNotFound: "找不到音效檔案：%s",
 

--- a/internal/tui/confirm.go
+++ b/internal/tui/confirm.go
@@ -134,7 +134,7 @@ func (m *Model) showKillTerminalConfirm(trackingKey, displayName string, pid int
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(title).
-				Affirmative("Kill").
+				Affirmative(locale.T(locale.KeyKillButton)).
 				Negative(locale.T(locale.KeyCancel)).
 				Value(confirmed),
 		),

--- a/internal/tui/confirm.go
+++ b/internal/tui/confirm.go
@@ -125,6 +125,25 @@ func (m *Model) showIssueConfirm(issueID, issueTitle string) {
 	}
 }
 
+// showKillTerminalConfirm displays a huh confirm dialog for killing a terminal process.
+func (m *Model) showKillTerminalConfirm(trackingKey, displayName string, pid int) {
+	title := fmt.Sprintf(locale.T(locale.KeyKillTerminalConfirm), displayName, pid)
+	confirmed := new(bool)
+	m.confirmResult = confirmed
+	m.confirmForm = huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(title).
+				Affirmative("Kill").
+				Negative(locale.T(locale.KeyCancel)).
+				Value(confirmed),
+		),
+	).WithWidth(50)
+	m.confirmAction = func() tea.Cmd {
+		return m.killTerminalCmd(trackingKey, displayName, pid)
+	}
+}
+
 // executePendingOp continues the original operation after labels are confirmed present.
 func (m *Model) executePendingOp() (tea.Model, tea.Cmd) {
 	op := m.pendingOp

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -25,6 +25,7 @@ type KeyMap struct {
 	Back        key.Binding
 	Confirm     key.Binding
 	FocusSwitch key.Binding
+	Kill        key.Binding
 
 	// Edit config sub-menu keys
 	Option1 key.Binding
@@ -58,6 +59,7 @@ func DefaultKeyMap() KeyMap {
 		Back:        key.NewBinding(key.WithKeys("esc"), key.WithHelp("Esc", "back")),
 		Confirm:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
 		FocusSwitch: key.NewBinding(key.WithKeys("tab"), key.WithHelp("Tab", "switch focus")),
+		Kill:        key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill terminal")),
 
 		Option1: key.NewBinding(key.WithKeys("1"), key.WithHelp("1", "option 1")),
 		Option2: key.NewBinding(key.WithKeys("2"), key.WithHelp("2", "option 2")),

--- a/internal/tui/launch.go
+++ b/internal/tui/launch.go
@@ -695,10 +695,16 @@ func (m Model) handleTerminalsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // sortedTerminalKeys returns sorted activeTerminals keys.
-// Caller must NOT hold a write lock (reads activeTerminals).
+// Caller must NOT hold any lock (acquires RLock internally).
 func (m Model) sortedTerminalKeys() []string {
 	m.state.RLock()
 	defer m.state.RUnlock()
+	return m.sortedTerminalKeysLocked()
+}
+
+// sortedTerminalKeysLocked returns sorted activeTerminals keys.
+// Caller must already hold at least RLock.
+func (m Model) sortedTerminalKeysLocked() []string {
 	keys := make([]string, 0, len(m.state.activeTerminals))
 	for k := range m.state.activeTerminals {
 		keys = append(keys, k)

--- a/internal/tui/launch.go
+++ b/internal/tui/launch.go
@@ -29,6 +29,7 @@ import (
 	"github.com/zac15987/zpit/internal/platform"
 	"github.com/zac15987/zpit/internal/terminal"
 	"github.com/zac15987/zpit/internal/tracker"
+	"github.com/zac15987/zpit/internal/watcher"
 	"github.com/zac15987/zpit/internal/worktree"
 )
 
@@ -586,21 +587,124 @@ func injectLangInstruction(md []byte) []byte {
 // --- Focus panel: loop slot selection ---
 
 func (m Model) handleFocusSwitch() (tea.Model, tea.Cmd) {
-	if m.focusedPanel == FocusLoopSlots {
+	// Determine which panels are available.
+	m.state.RLock()
+	hasTerminals := len(m.state.activeTerminals) > 0
+	m.state.RUnlock()
+
+	project := m.state.projects[m.cursor]
+	m.state.RLock()
+	slotKeys := m.sortedSlotKeys(project.ID)
+	m.state.RUnlock()
+	hasSlots := len(slotKeys) > 0
+
+	// Build ordered list of available panels: Projects -> Terminals -> LoopSlots.
+	panels := []FocusedPanel{FocusProjects}
+	if hasTerminals {
+		panels = append(panels, FocusTerminals)
+	}
+	if hasSlots {
+		panels = append(panels, FocusLoopSlots)
+	}
+
+	// If only Projects panel is available, do nothing.
+	if len(panels) <= 1 {
+		return m, nil
+	}
+
+	// Find current panel index and advance to next.
+	current := 0
+	for i, p := range panels {
+		if p == m.focusedPanel {
+			current = i
+			break
+		}
+	}
+	next := panels[(current+1)%len(panels)]
+
+	m.focusedPanel = next
+	switch next {
+	case FocusTerminals:
+		m.termCursor = 0
+	case FocusLoopSlots:
+		m.focusProjectID = project.ID
+		m.loopCursor = 0
+	}
+	return m, nil
+}
+
+// --- Focus panel: terminal selection ---
+
+func (m Model) handleTerminalsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	termKeys := m.sortedTerminalKeys()
+	if len(termKeys) == 0 {
 		m.focusedPanel = FocusProjects
 		return m, nil
 	}
-	project := m.state.projects[m.cursor]
-	m.state.RLock()
-	keys := m.sortedSlotKeys(project.ID)
-	m.state.RUnlock()
-	if len(keys) == 0 {
-		return m, nil
+	if m.termCursor >= len(termKeys) {
+		m.termCursor = len(termKeys) - 1
 	}
-	m.focusedPanel = FocusLoopSlots
-	m.focusProjectID = project.ID
-	m.loopCursor = 0
+
+	switch {
+	case key.Matches(msg, m.keys.Back):
+		m.focusedPanel = FocusProjects
+		return m, nil
+
+	case key.Matches(msg, m.keys.Up):
+		if m.termCursor > 0 {
+			m.termCursor--
+		}
+
+	case key.Matches(msg, m.keys.Down):
+		if m.termCursor < len(termKeys)-1 {
+			m.termCursor++
+		}
+
+	case key.Matches(msg, m.keys.PageUp):
+		m.viewport.PageUp()
+
+	case key.Matches(msg, m.keys.PageDown):
+		m.viewport.PageDown()
+
+	case key.Matches(msg, m.keys.Kill):
+		trackingKey := termKeys[m.termCursor]
+		m.state.RLock()
+		at, ok := m.state.activeTerminals[trackingKey]
+		if !ok {
+			m.state.RUnlock()
+			return m, nil
+		}
+		pid := at.SessionPID
+		state := at.State
+		displayName := m.projectName(trackingKey)
+		m.state.RUnlock()
+
+		if pid == 0 {
+			m.setStatus(locale.T(locale.KeyTerminalNoPID))
+			return m, nil
+		}
+		if state == watcher.StateEnded {
+			m.setStatus(locale.T(locale.KeyTerminalAlreadyEnded))
+			return m, nil
+		}
+		m.showKillTerminalConfirm(trackingKey, displayName, pid)
+		return m, m.confirmForm.Init()
+	}
+
 	return m, nil
+}
+
+// sortedTerminalKeys returns sorted activeTerminals keys.
+// Caller must NOT hold a write lock (reads activeTerminals).
+func (m Model) sortedTerminalKeys() []string {
+	m.state.RLock()
+	defer m.state.RUnlock()
+	keys := make([]string, 0, len(m.state.activeTerminals))
+	for k := range m.state.activeTerminals {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (m Model) handleLoopSlotsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -959,13 +959,15 @@ func (m Model) handleAgentEvent(msg AgentEventMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handleKillTerminal(msg KillTerminalMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
-		m.setStatus(fmt.Sprintf("Kill failed: %s", msg.Err))
+		m.setStatus(fmt.Sprintf(locale.T(locale.KeyKillFailed), msg.Err))
 		return m, nil
 	}
 
 	m.state.Lock()
 	at, ok := m.state.activeTerminals[msg.TrackingKey]
+	var pid int
 	if ok {
+		pid = at.SessionPID
 		if at.Watcher != nil {
 			at.Watcher.Stop()
 		}
@@ -977,7 +979,7 @@ func (m Model) handleKillTerminal(msg KillTerminalMsg) (tea.Model, tea.Cmd) {
 
 	if ok {
 		displayName := m.projectName(msg.TrackingKey)
-		m.setStatus(fmt.Sprintf(locale.T(locale.KeyKillTerminal), displayName, at.SessionPID))
+		m.setStatus(fmt.Sprintf(locale.T(locale.KeyKillTerminal), displayName, pid))
 	}
 
 	return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -356,6 +356,9 @@ func (m Model) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case IssueConfirmedMsg:
 		return m.handleIssueConfirmed(msg)
 
+	case KillTerminalMsg:
+		return m.handleKillTerminal(msg)
+
 	// Loop engine messages
 	case LoopPollMsg:
 		return m.handleLoopPoll(msg)
@@ -951,6 +954,32 @@ func (m Model) handleAgentEvent(msg AgentEventMsg) (tea.Model, tea.Cmd) {
 	if w != nil {
 		return m, watchNextCmd(msg.ProjectID, w)
 	}
+	return m, nil
+}
+
+func (m Model) handleKillTerminal(msg KillTerminalMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		m.setStatus(fmt.Sprintf("Kill failed: %s", msg.Err))
+		return m, nil
+	}
+
+	m.state.Lock()
+	at, ok := m.state.activeTerminals[msg.TrackingKey]
+	if ok {
+		if at.Watcher != nil {
+			at.Watcher.Stop()
+		}
+		at.State = watcher.StateEnded
+		at.StateChangedAt = time.Now()
+		m.state.NotifyAll()
+	}
+	m.state.Unlock()
+
+	if ok {
+		displayName := m.projectName(msg.TrackingKey)
+		m.setStatus(fmt.Sprintf(locale.T(locale.KeyKillTerminal), displayName, at.SessionPID))
+	}
+
 	return m, nil
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -56,6 +56,7 @@ type FocusedPanel int
 
 const (
 	FocusProjects  FocusedPanel = iota
+	FocusTerminals
 	FocusLoopSlots
 )
 
@@ -132,6 +133,7 @@ type Model struct {
 	// Focus panel state (loop slot selection)
 	focusedPanel   FocusedPanel
 	loopCursor     int
+	termCursor     int
 	focusProjectID string
 
 	// Viewport for scrollable content

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -519,6 +519,11 @@ func (m Model) handleProjectsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleFocusSwitch()
 	}
 
+	// If focused on terminals, delegate key handling.
+	if m.focusedPanel == FocusTerminals {
+		return m.handleTerminalsKey(msg)
+	}
+
 	// If focused on loop slots, delegate key handling.
 	if m.focusedPanel == FocusLoopSlots {
 		return m.handleLoopSlotsKey(msg)

--- a/internal/tui/msg.go
+++ b/internal/tui/msg.go
@@ -201,3 +201,11 @@ type ChannelListenUpdatedMsg struct {
 	NewListen []string
 	Err       error
 }
+
+// --- Terminal kill messages ---
+
+// KillTerminalMsg carries the result of killing a terminal process.
+type KillTerminalMsg struct {
+	TrackingKey string
+	Err         error
+}

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -475,6 +475,26 @@ func waitForLogCmd(projectID string, pid int, sessionID, logPath, workDir string
 	}
 }
 
+// killTerminalCmd sends SIGKILL/TerminateProcess to the given PID.
+// Must NOT be called while holding a lock.
+func (m Model) killTerminalCmd(trackingKey, displayName string, pid int) tea.Cmd {
+	logger := m.state.logger
+	return func() tea.Msg {
+		logger.Printf("terminal kill: key=%s pid=%d", trackingKey, pid)
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			logger.Printf("terminal kill: FindProcess failed: key=%s pid=%d err=%v", trackingKey, pid, err)
+			return KillTerminalMsg{TrackingKey: trackingKey, Err: fmt.Errorf("find process %d: %w", pid, err)}
+		}
+		if err := proc.Kill(); err != nil {
+			logger.Printf("terminal kill: Kill failed: key=%s pid=%d err=%v", trackingKey, pid, err)
+			return KillTerminalMsg{TrackingKey: trackingKey, Err: fmt.Errorf("kill process %d: %w", pid, err)}
+		}
+		logger.Printf("terminal kill: success key=%s pid=%d", trackingKey, pid)
+		return KillTerminalMsg{TrackingKey: trackingKey, Err: nil}
+	}
+}
+
 func tickCmd() tea.Cmd {
 	return tea.Tick(tickInterval, func(t time.Time) tea.Msg {
 		return TickMsg(t)

--- a/internal/tui/view_projects.go
+++ b/internal/tui/view_projects.go
@@ -242,7 +242,8 @@ func (m Model) renderActiveTerminals() string {
 	b.WriteString("  " + strings.Repeat(boxHoriz, 50) + "\n")
 
 	// Sort keys for stable render order.
-	termKeys := m.sortedTerminalKeys()
+	// Use locked variant — caller (syncViewportContent) already holds RLock.
+	termKeys := m.sortedTerminalKeysLocked()
 
 	i := 1
 	for _, projectID := range termKeys {

--- a/internal/tui/view_projects.go
+++ b/internal/tui/view_projects.go
@@ -90,9 +90,12 @@ func (m Model) renderProjectsFooter() string {
 		b.WriteString(statusBarStyle.Render(" " + m.statusMessage + " "))
 	}
 	b.WriteString("\n")
-	if m.focusedPanel == FocusLoopSlots {
+	switch m.focusedPanel {
+	case FocusTerminals:
+		b.WriteString(helpStyle.Render(locale.T(locale.KeyTerminalHelp)))
+	case FocusLoopSlots:
 		b.WriteString(helpStyle.Render(locale.T(locale.KeyLoopSlotHelp)))
-	} else {
+	default:
 		b.WriteString(helpStyle.Render(locale.T(locale.KeyHelpFooter)))
 	}
 	return b.String()
@@ -116,7 +119,7 @@ func (m Model) renderHeader() string {
 func (m Model) renderProjectList() string {
 	var b strings.Builder
 	titleStyle := sectionTitleStyle
-	if m.focusedPanel == FocusLoopSlots {
+	if m.focusedPanel != FocusProjects {
 		titleStyle = detailStyle
 	}
 	b.WriteString(titleStyle.Render(locale.T(locale.KeyProjects)))
@@ -181,7 +184,8 @@ func (m Model) renderHotkeys() string {
 		{"m", locale.T(locale.KeyChannelComm), false},
 		{"a", locale.T(locale.KeyAddProject), true},
 		{"e", locale.T(locale.KeyEditConfig), false},
-		{"Tab", locale.T(locale.KeyFocusSlot), true},
+		{"x", locale.T(locale.KeyCloseTerminal), true},
+		{"Tab", locale.T(locale.KeySwitchPanel), false},
 		{"?", locale.T(locale.KeyHelp), false},
 		{"q", locale.T(locale.KeyQuit), false},
 	}
@@ -229,16 +233,16 @@ func (m Model) projectName(id string) string {
 
 func (m Model) renderActiveTerminals() string {
 	var b strings.Builder
-	b.WriteString(sectionTitleStyle.Render(locale.T(locale.KeyActiveTerminals)))
+	titleStyle := detailStyle
+	if m.focusedPanel == FocusTerminals {
+		titleStyle = sectionTitleStyle
+	}
+	b.WriteString(titleStyle.Render(locale.T(locale.KeyActiveTerminals)))
 	b.WriteString("\n")
 	b.WriteString("  " + strings.Repeat(boxHoriz, 50) + "\n")
 
 	// Sort keys for stable render order.
-	termKeys := make([]string, 0, len(m.state.activeTerminals))
-	for k := range m.state.activeTerminals {
-		termKeys = append(termKeys, k)
-	}
-	sort.Strings(termKeys)
+	termKeys := m.sortedTerminalKeys()
 
 	i := 1
 	for _, projectID := range termKeys {
@@ -255,7 +259,12 @@ func (m Model) renderActiveTerminals() string {
 			displayName += " 🌿" + at.WorktreeBranch
 		}
 
-		b.WriteString(fmt.Sprintf("  [%d] %s %s %s %s\n",
+		prefix := "  "
+		if m.focusedPanel == FocusTerminals && (i-1) == m.termCursor {
+			prefix = " ›"
+		}
+		b.WriteString(fmt.Sprintf("%s[%d] %s %s %s %s\n",
+			prefix,
 			i,
 			selectedStyle.Render(displayName),
 			boxVert,


### PR DESCRIPTION
## Summary

- Add terminal focus panel (`FocusTerminals`) to ViewProjects main screen, enabling Tab to cycle through three panels: Projects → Terminals → LoopSlots (skipping empty panels)
- Add `x` key to kill selected terminal with confirm dialog, using `os.FindProcess(pid).Kill()` for cross-platform process termination
- Add cursor indicator (`›`) in active terminals area when focused, with ↑↓ navigation and Esc to return

### Changes by task

- **T1**: `FocusTerminals` enum, `termCursor` field, `Kill` key binding (`x`), `KillTerminalMsg` type
- **T2**: 7 new locale keys with en + zh-TW translations
- **T3**: 3-panel cycling in `handleFocusSwitch`, `handleTerminalsKey` for terminal panel input
- **T4**: `showKillTerminalConfirm` dialog, `killTerminalCmd` with logging
- **T5**: Cursor rendering in `renderActiveTerminals`, `[x]` in hotkeys, terminal-specific footer
- **T6**: `KillTerminalMsg` dispatch and handler (stop watcher, set StateEnded, NotifyAll)
- **T7**: Updated `02-tui-design.md` mockup and `CLAUDE.md` focus panel documentation

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Launch TUI, verify Tab cycles only to panels with content
- [ ] Launch a terminal, Tab to terminals panel, verify `›` cursor appears
- [ ] Press ↑↓ to navigate terminals, Esc to return to projects
- [ ] Press `x` on active terminal, verify confirm dialog appears
- [ ] Confirm kill, verify process terminates and terminal shows "ended"
- [ ] Press `x` on ended terminal, verify status message (not dialog)
- [ ] Verify hotkeys section shows `[x] Close Terminal` and `[Tab] Switch Panel`
- [ ] Verify footer text changes per focused panel

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
