### PR TITLE
feat(loop): sync local base branch after PR merge

### DIFF
--- a/docs/architecture/07-worktree-and-loop.md
+++ b/docs/architecture/07-worktree-and-loop.md
@@ -53,6 +53,7 @@ Issue 進入 In Progress
     ├─ 6. PR merge 後清理
     │     git worktree remove <worktree-path>
     │     git branch -d feat/ISSUE-ID-slug
+    │     git fetch origin <base>:<base>  （更新主目錄本地 base branch ref）
     │
     └─ 7. Issue → Done
 ```
@@ -140,6 +141,8 @@ TUI 按 [l]
 │  │    └─ label 未變 → 繼續輪詢                            │
 │  │                                                        │
 │  │ 9. 偵測 PR merged → 清理 worktree + branch             │
+│  │    + 同步本地 base branch（git fetch origin <base>:<base>）│
+│  │    失敗時 log warning，不中斷 issue 關閉流程             │
 │  │                                                        │
 │  │ 10. 回到步驟 1 抓下一個 issue                          │
 │  │                                                        │
@@ -167,7 +170,7 @@ SlotReviewing           reviewer 工作中（poll labels 等待 "ai-review" 或 
        ↓                           ↓
 SlotWaitingPRMerge      SlotCoding (needs-changes → 重跑，round++)
        ↓
-SlotCleaningUp          清理 worktree + branch
+SlotCleaningUp          清理 worktree + branch + 同步本地 base branch ref
        ↓
 SlotDone                完成
 

--- a/internal/git/ops.go
+++ b/internal/git/ops.go
@@ -42,6 +42,14 @@ func Pull(ctx context.Context, cwd string) (stdout, stderr string, err error) {
 	return runGitSeparate(ctx, cwd, "pull", "--ff-only")
 }
 
+// FetchBranch runs `git fetch origin <branch>:<branch>` in cwd.
+// This updates the local branch ref to match the remote without touching the working tree.
+// Returns stdout, stderr, and any error from git.
+func FetchBranch(ctx context.Context, cwd, branch string) (stdout, stderr string, err error) {
+	refspec := branch + ":" + branch
+	return runGitSeparate(ctx, cwd, "fetch", "origin", refspec)
+}
+
 // LogGraph runs `git log --graph --oneline --all --decorate --color=always -n 50`.
 // Returns the raw (ANSI-colored) stdout. If stderr contains "does not have any commits yet"
 // or exit code indicates no commits, return ("", nil) so the caller can render a sentinel.

--- a/internal/git/ops_test.go
+++ b/internal/git/ops_test.go
@@ -330,10 +330,22 @@ func TestParseAheadBehind(t *testing.T) {
 	}
 }
 
+// gitRevParse runs `git rev-parse <ref>` in dir and returns the trimmed SHA.
+func gitRevParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %s in %s: %v", ref, dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func TestFetchBranch(t *testing.T) {
 	skipIfNoGit(t)
 
-	t.Run("success: remote has new commit, local ref is updated", func(t *testing.T) {
+	t.Run("fast-forward: remote has new commit, local ref advances to match origin/dev", func(t *testing.T) {
 		localDir, bareDir := initFetchTestRepo(t)
 		ctx := context.Background()
 
@@ -377,15 +389,11 @@ func TestFetchBranch(t *testing.T) {
 			t.Fatalf("FetchBranch returned error: %v (stdout=%q stderr=%q)", err, stdout, stderr)
 		}
 
-		// Verify the new commit appears in the local dev ref.
-		cmd := exec.Command("git", "log", "--oneline", "-1", "dev")
-		cmd.Dir = localDir
-		out, logErr := cmd.CombinedOutput()
-		if logErr != nil {
-			t.Fatalf("git log dev: %s: %v", out, logErr)
-		}
-		if !strings.Contains(string(out), "add new feature after merge") {
-			t.Errorf("local dev log = %q, expected to contain %q", string(out), "add new feature after merge")
+		// Verify local dev ref now matches origin/dev exactly.
+		devSHA := gitRevParse(t, localDir, "dev")
+		originDevSHA := gitRevParse(t, localDir, "origin/dev")
+		if devSHA != originDevSHA {
+			t.Errorf("after fetch: dev=%s != origin/dev=%s", devSHA, originDevSHA)
 		}
 	})
 
@@ -397,6 +405,70 @@ func TestFetchBranch(t *testing.T) {
 		_, _, err := FetchBranch(ctx, localDir, "dev")
 		if err != nil {
 			t.Fatalf("FetchBranch returned error on already-synced branch: %v", err)
+		}
+	})
+
+	t.Run("diverged: local dev has commit not in remote, returns non-nil error and leaves ref unchanged", func(t *testing.T) {
+		localDir, _ := initFetchTestRepo(t)
+		ctx := context.Background()
+
+		// Create a local commit on dev that is not pushed to the bare remote.
+		for _, args := range [][]string{
+			{"git", "checkout", "dev"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = localDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %s: %v", args[1:], out, err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(localDir, "local-only.txt"), []byte("local work"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"git", "add", "local-only.txt"},
+			{"git", "commit", "-m", "diverge: local-only commit"},
+			// Return to main so dev is not checked out during FetchBranch.
+			{"git", "checkout", "main"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = localDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %s: %v", args[1:], out, err)
+			}
+		}
+
+		// Capture local dev SHA before the (expected-to-fail) fetch.
+		beforeSHA := gitRevParse(t, localDir, "dev")
+
+		// FetchBranch must return non-nil err: git refuses a non-fast-forward update.
+		_, _, fetchErr := FetchBranch(ctx, localDir, "dev")
+		if fetchErr == nil {
+			t.Fatal("FetchBranch expected non-nil error on diverged branch, got nil")
+		}
+
+		// Local dev ref must remain unchanged after the rejection.
+		afterSHA := gitRevParse(t, localDir, "dev")
+		if afterSHA != beforeSHA {
+			t.Errorf("local dev ref changed after rejected fetch: before=%s after=%s", beforeSHA, afterSHA)
+		}
+	})
+
+	t.Run("head-on-branch: dev is currently checked out, propagates git exit status", func(t *testing.T) {
+		localDir, _ := initFetchTestRepo(t)
+		ctx := context.Background()
+
+		// Check out dev so HEAD points at it; git refuses to update a checked-out branch.
+		checkoutCmd := exec.Command("git", "checkout", "dev")
+		checkoutCmd.Dir = localDir
+		if out, err := checkoutCmd.CombinedOutput(); err != nil {
+			t.Fatalf("git checkout dev: %s: %v", out, err)
+		}
+
+		// FetchBranch must propagate git's non-zero exit: no panic, err != nil.
+		stdout, stderr, err := FetchBranch(ctx, localDir, "dev")
+		if err == nil {
+			t.Fatalf("FetchBranch expected non-nil error when dev is checked out, got nil (stdout=%q stderr=%q)", stdout, stderr)
 		}
 	})
 

--- a/internal/git/ops_test.go
+++ b/internal/git/ops_test.go
@@ -1,9 +1,84 @@
 package git
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// skipIfNoGit skips the test if git is not available in PATH.
+func skipIfNoGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+}
+
+// initFetchTestRepo creates a local repo backed by a bare remote suitable for FetchBranch tests.
+// Returns (localRepoPath, bareRemotePath). The local repo has "origin" pointing to the bare
+// remote with a "dev" branch and one initial commit already pushed and in sync.
+func initFetchTestRepo(t *testing.T) (localDir, bareDir string) {
+	t.Helper()
+
+	// Create bare repo as origin.
+	bareDir = t.TempDir()
+	{
+		cmd := exec.Command("git", "init", "--bare")
+		cmd.Dir = bareDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bare repo init: %s: %v", out, err)
+		}
+	}
+
+	// Clone bare repo to create local.
+	localDir = filepath.Join(t.TempDir(), "local")
+	{
+		cmd := exec.Command("git", "clone", bareDir, localDir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("clone: %s: %v", out, err)
+		}
+	}
+
+	// Configure user in local.
+	for _, args := range [][]string{
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = localDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args[1:], out, err)
+		}
+	}
+
+	// Create dev branch with initial commit and push.
+	// Then create and check out a separate "main" branch so that "dev" is a local
+	// branch but not currently checked out — git refuses to update a checked-out
+	// branch via `fetch origin dev:dev`, so the test must run with HEAD elsewhere.
+	if err := os.WriteFile(filepath.Join(localDir, "README.md"), []byte("# test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "checkout", "-b", "dev"},
+		{"git", "add", "README.md"},
+		{"git", "commit", "-m", "initial"},
+		{"git", "push", "-u", "origin", "dev"},
+		// Leave HEAD on a separate branch so "dev" is not checked out.
+		{"git", "checkout", "-b", "main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = localDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args[1:], out, err)
+		}
+	}
+
+	return localDir, bareDir
+}
 
 func TestParseLocalBranches(t *testing.T) {
 	tests := []struct {
@@ -253,4 +328,85 @@ func TestParseAheadBehind(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFetchBranch(t *testing.T) {
+	skipIfNoGit(t)
+
+	t.Run("success: remote has new commit, local ref is updated", func(t *testing.T) {
+		localDir, bareDir := initFetchTestRepo(t)
+		ctx := context.Background()
+
+		// Clone bare repo into a second working copy and push a new commit to origin/dev.
+		otherDir := filepath.Join(t.TempDir(), "other")
+		{
+			cmd := exec.Command("git", "clone", bareDir, otherDir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("clone other: %s: %v", out, err)
+			}
+		}
+		for _, args := range [][]string{
+			{"git", "config", "user.email", "other@test.com"},
+			{"git", "config", "user.name", "Other"},
+			{"git", "checkout", "dev"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = otherDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("other git %v: %s: %v", args[1:], out, err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(otherDir, "new-feature.txt"), []byte("new work"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"git", "add", "new-feature.txt"},
+			{"git", "commit", "-m", "add new feature after merge"},
+			{"git", "push", "origin", "dev"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = otherDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("other git %v: %s: %v", args[1:], out, err)
+			}
+		}
+
+		// Local repo has not fetched yet — FetchBranch should update the local dev ref.
+		stdout, stderr, err := FetchBranch(ctx, localDir, "dev")
+		if err != nil {
+			t.Fatalf("FetchBranch returned error: %v (stdout=%q stderr=%q)", err, stdout, stderr)
+		}
+
+		// Verify the new commit appears in the local dev ref.
+		cmd := exec.Command("git", "log", "--oneline", "-1", "dev")
+		cmd.Dir = localDir
+		out, logErr := cmd.CombinedOutput()
+		if logErr != nil {
+			t.Fatalf("git log dev: %s: %v", out, logErr)
+		}
+		if !strings.Contains(string(out), "add new feature after merge") {
+			t.Errorf("local dev log = %q, expected to contain %q", string(out), "add new feature after merge")
+		}
+	})
+
+	t.Run("no new commits: remote and local are in sync, returns nil error", func(t *testing.T) {
+		localDir, _ := initFetchTestRepo(t)
+		ctx := context.Background()
+
+		// Local and remote are already in sync after initFetchTestRepo.
+		_, _, err := FetchBranch(ctx, localDir, "dev")
+		if err != nil {
+			t.Fatalf("FetchBranch returned error on already-synced branch: %v", err)
+		}
+	})
+
+	t.Run("branch does not exist on remote: returns non-nil error", func(t *testing.T) {
+		localDir, _ := initFetchTestRepo(t)
+		ctx := context.Background()
+
+		_, _, err := FetchBranch(ctx, localDir, "nonexistent-branch")
+		if err == nil {
+			t.Fatal("FetchBranch expected non-nil error for nonexistent remote branch, got nil")
+		}
+	})
 }

--- a/internal/tui/loop_cmds.go
+++ b/internal/tui/loop_cmds.go
@@ -12,6 +12,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/zac15987/zpit/internal/git"
 	"github.com/zac15987/zpit/internal/locale"
 	"github.com/zac15987/zpit/internal/loop"
 	"github.com/zac15987/zpit/internal/platform"
@@ -620,6 +621,7 @@ func (m Model) loopCleanupCmd(projectID, issueID string) tea.Cmd {
 		return nil
 	}
 	wtPath := slot.WorktreePath
+	baseBranch := slot.BaseBranch
 	m.state.RUnlock()
 
 	mgr := m.state.wtManager
@@ -633,6 +635,20 @@ func (m Model) loopCleanupCmd(projectID, issueID string) tea.Cmd {
 		removeErr := mgr.Remove(projectPath, wtPath, true)
 		if removeErr != nil {
 			logger.Printf("loop: worktree remove failed #%s: %v (will still close issue)", issueID, removeErr)
+		}
+
+		// Sync the main project directory's local base branch ref.
+		// Use a separate 15-second timeout so a slow fetch does not eat into CloseIssue budget.
+		{
+			fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer fetchCancel()
+			if _, _, fetchErr := git.FetchBranch(fetchCtx, projectPath, baseBranch); fetchErr != nil {
+				logger.Printf("loop: base branch sync failed project=%s issue=#%s branch=%s: %v",
+					projectID, issueID, baseBranch, fetchErr)
+			} else {
+				logger.Printf("loop: synced base branch project=%s issue=#%s branch=%s",
+					projectID, issueID, baseBranch)
+			}
 		}
 
 		// Always close the issue regardless of worktree removal result.

--- a/internal/tui/loop_cmds.go
+++ b/internal/tui/loop_cmds.go
@@ -639,16 +639,17 @@ func (m Model) loopCleanupCmd(projectID, issueID string) tea.Cmd {
 
 		// Sync the main project directory's local base branch ref.
 		// Use a separate 15-second timeout so a slow fetch does not eat into CloseIssue budget.
-		{
-			fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 15*time.Second)
-			defer fetchCancel()
-			if _, _, fetchErr := git.FetchBranch(fetchCtx, projectPath, baseBranch); fetchErr != nil {
-				logger.Printf("loop: base branch sync failed project=%s issue=#%s branch=%s: %v",
-					projectID, issueID, baseBranch, fetchErr)
-			} else {
-				logger.Printf("loop: synced base branch project=%s issue=#%s branch=%s",
-					projectID, issueID, baseBranch)
-			}
+		// fetchCancel is called explicitly (not deferred) so the context is released immediately
+		// after FetchBranch returns, rather than lingering through CloseIssue.
+		fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		_, _, fetchErr := git.FetchBranch(fetchCtx, projectPath, baseBranch)
+		fetchCancel()
+		if fetchErr != nil {
+			logger.Printf("loop: base branch sync failed project=%s issue=#%s branch=%s: %v",
+				projectID, issueID, baseBranch, fetchErr)
+		} else {
+			logger.Printf("loop: synced base branch project=%s issue=#%s branch=%s",
+				projectID, issueID, baseBranch)
 		}
 
 		// Always close the issue regardless of worktree removal result.


### PR DESCRIPTION
## Summary

- Exports `git.FetchBranch(ctx, cwd, branch)` in `internal/git/ops.go` — runs `git fetch origin <branch>:<branch>` via the existing `runGitSeparate` helper, updating the local branch ref without touching the working tree.
- Wires `FetchBranch` into `loopCleanupCmd` (`internal/tui/loop_cmds.go`): after worktree removal, before `CloseIssue`, with a fresh 15-second timeout; failure is logged and does not block issue closing.
- Updates `docs/architecture/07-worktree-and-loop.md` at three sites (lifecycle step 6, loop flow step 9, state machine SlotCleaningUp) to document the base sync behavior.

## Test plan

- [ ] `go test ./internal/git/... -run TestFetchBranch` — three sub-tests: success (new remote commit updates local ref), idempotent (already in sync → nil error), nonexistent branch (→ error)
- [ ] `go test ./internal/tui/...` — existing loop cleanup tests pass unmodified
- [ ] `go build ./...` — clean build, no new lint/vet issues
- [ ] Manual: start a loop, let a PR merge — observe `loop: synced base branch` log line and confirm local `dev` ref advances to `origin/dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
