### PR TITLE
[111] M4: zplex launcher backend, agent_state sync, auto_close_after_done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,11 @@ internal/
 ├── prompt/              # Prompt assembly: BuildCodingPrompt (subagent/team delegation), BuildReviewerPrompt, BuildRevisionPrompt
 ├── sessionsync/         # Session bundle pack/unpack + cross-OS cwd rewrite (zip + manifest)
 ├── ssh/                 # Wish SSH server: StartServerAsync(), ServerHandle, StartServer(), auth config
-├── terminal/            # LaunchClaude() dispatch + platform-specific launchers (wt.exe / tmux)
+├── terminal/            # LaunchClaude() dispatch + platform-specific launchers; launch priority: zplex probe → wt.exe → tmux → error
 ├── tracker/             # TrackerClient interface: ForgejoClient + GitHubClient REST abstractions
 ├── watcher/             # Session log monitoring: EncodeCwd, ParseLine, FindActiveSessions, Watcher
 ├── worktree/            # Worktree Manager, Slugify(), DeployHooksToProject(), DeployHooksToWorktree(), settings.json merge
+├── zplex/               # HTTP client for the zplex launch-backend daemon (Health/CreateSession/PatchAgentState)
 └── tui/                 # Bubble Tea TUI — see docs/architecture/02-tui-design.md + 10-appstate.md
     ├── appstate.go      # AppState struct, RWMutex, Subscribe/NotifyAll pub/sub
     ├── channel.go       # Channel EventBus subscription and event reading
@@ -101,6 +102,7 @@ Full architecture lives in `docs/architecture/` (English, one file per topic —
 - **Parallel `[P]` task batches** — the orchestrator spawns one `task-runner` per task with `isolation: "worktree"`. After they return: discover each branch with `git -C <path> rev-parse --abbrev-ref HEAD` (CC doesn't propagate `worktreeBranch` — known-issues §3), cherry-pick in task-ID order, then clean up as **TWO separate Bash calls** — `git worktree remove --force` then `git branch -D`, never chained with `&&` (a hook block on one must not skip the other — §4). `isolation = "in_project"` force-disables `[P]` (one working tree can't host parallel children).
 - **Hook gate** — every hook `exit 0`s unless `ZPIT_AGENT=1`, so non-zpit Claude Code sessions are untouched. Worktrees get a dual-write of `.claude/settings.json` + `settings.local.json` (a linked worktree doesn't inherit the main repo's settings — Issue #39); `in_project` instead *merges* into the real repo's `settings.json` and self-ignores a zpit-created `.gitignore`.
 - **go:embed deploy** — agents/hooks/docs are embedded in the binary and redeployed to the target project/worktree on every launch, so editing `agents/*.md`, `hooks/*.sh`, or `docs/agent-guidelines.md` requires a rebuild to take effect. `[f]` (efficiency) launches without hooks.
+- **Auto-close after review PASS** — when `auto_close_after_done` (global, default `true`) is enabled, the loop kills a slot's own coder+reviewer terminals after a review PASS verdict (`ai-review` label). For the zplex backend, panels close via process exit. `needs-changes` never triggers closing. `loop.Slot` accumulates a per-round session-reference list to track which terminals to close at round completion.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -192,12 +192,19 @@ Config lives at `~/.zpit/config.toml`. Override with `ZPIT_CONFIG` env var.
 ```toml
 language = "en"             # en | zh-TW
 broker_port = 17731         # HTTP broker port for cross-agent channel
+auto_close_after_done = true  # kill the slot's coder+reviewer terminals after review PASS
+                               # (ai-review label); zplex panels close via process exit.
+                               # needs-changes never triggers closing. Hot-reloadable.
 # zpit_bin = "/usr/local/bin/zpit"  # explicit binary path for .mcp.json generation
 
 [terminal]
 windows_mode = "new_tab"    # new_tab | new_window
 tmux_mode = "new_window"    # new_window | new_pane
 # windows_terminal_profile = "PowerShell 7"  # WT profile name for -p flag
+# zplex_port = 17732        # TCP port of the local zplex daemon (launch backend).
+                             # 0 disables the zplex backend; launch priority is
+                             # zplex probe → Windows Terminal → tmux → error.
+                             # Hot-reloadable.
 
 [notification]
 tui_alert = true

--- a/docs/architecture/03-system-architecture.md
+++ b/docs/architecture/03-system-architecture.md
@@ -88,18 +88,69 @@
 
 Responsible for opening a new terminal window in the correct environment and launching Claude Code.
 Behavior is controlled by the `[terminal]` section of config.toml.
-Implementation lives in `internal/terminal/`.
+Implementation lives in `internal/terminal/`; the zplex HTTP client lives in `internal/zplex/`.
+
+### Launch Priority
+
+Every launch entry point (`LaunchClaude`, `LaunchClaudeInDir`, `LaunchLazygit`, `LaunchClaudeUpdate`) follows the same priority chain:
+
+```
+zplex probe → Windows Terminal (wt.exe) → tmux → error
+```
+
+### zplex Backend
+
+When `terminal.zplex_port > 0`, zpit probes the local zplex daemon before falling back to the
+platform-native terminal:
+
+1. **Probe**: `GET http://127.0.0.1:<zplex_port>/api/health` with a 500ms timeout (no caching —
+   one probe per launch call). If the response is HTTP 200, the session is created via
+   `POST /api/sessions` on the daemon and appears as a panel in the zplex web frontend.
+2. **Fallback**: if the probe fails (timeout / non-200 / unreachable), zpit falls back to
+   `platform.Detect()` (Windows Terminal → tmux → error) exactly as before.
+3. **Disabled**: when `zplex_port = 0`, the probe is skipped entirely — no HTTP request is made —
+   and zpit behaves as if zplex does not exist.
+
+**POST body** sent to `POST /api/sessions`:
+
+| Field | Value |
+|---|---|
+| `shell` | required |
+| `title` | required |
+| `cwd` | optional working directory |
+| `args` | optional argument list |
+| `env` | optional; **replaces** the child environment (not merged). Agent sessions that need hook enforcement send `append(os.Environ(), "ZPIT_AGENT=1", "ZPIT_AGENT_TYPE=<role>")`. Plain claude / lazygit / update sessions omit this field. |
+| `source` | `"zpit"` (identity metadata) |
+| `project_id` | zpit project ID |
+| `issue_id` | issue ID (if applicable) |
+| `role` | agent role string |
+| `agent_state` | initial agent state (`"active"` for agent sessions; empty otherwise) |
+
+The zpit-env/zpit-exit wrapper scripts are **not** used on the zplex path. Panel lifecycle is
+managed by the daemon's `session.closed` event on process exit; zpit never issues a DELETE call.
+
+**Platform package boundary**: `platform.Detect()` and the existing `platform.Env*` constants are
+unchanged. A new `platform.EnvZplex` enum value (String() = `"zplex"`) is added solely as a
+display marker in `LaunchResult.Env`; the detection logic itself remains in `platform.Detect()`
+and is never modified.
 
 ```go
 // pseudocode
 func LaunchClaude(project Project, config Config) {
     path := project.PathForCurrentOS()
 
+    // 1. zplex probe (skipped when zplex_port == 0)
+    if config.Terminal.ZplexPort > 0 {
+        if probeZplex(config.Terminal.ZplexPort) {
+            return launchViaZplex(config.Terminal.ZplexPort, path, project)
+        }
+    }
+
+    // 2. fall back to platform-native terminal
     switch detectEnvironment() {
     case WindowsTerminal:
         switch config.Terminal.WindowsMode {
         case "new_tab":
-            // default: open a new tab in Windows Terminal
             exec("wt.exe", "new-tab", "-d", path, "--title", project.Name, "--", "claude")
         case "new_window":
             exec("wt.exe", "-w", "new", "-d", path, "--title", project.Name, "--", "claude")

--- a/docs/architecture/04-config.md
+++ b/docs/architecture/04-config.md
@@ -14,12 +14,22 @@ On first launch, if no config exists, a template is generated automatically (`co
 # ~/.zpit/config.toml
 
 # ──────────────────────────────────────────────
+# Global settings
+# ──────────────────────────────────────────────
+auto_close_after_done = true  # when true, after a slot's review PASSES zpit kills that slot's
+                               # coder+reviewer terminals (closes zplex panels via process exit).
+                               # Hot-reloadable; read at PASS-handling time. Applies only to
+                               # slot-launched sessions; clarifier/efficiency/desktop/manual
+                               # sessions are never affected.
+
+# ──────────────────────────────────────────────
 # Terminal settings
 # ──────────────────────────────────────────────
 [terminal]
 windows_mode = "new_tab"    # "new_tab" | "new_window"
 tmux_mode = "new_window"    # "new_window" | "new_pane"
 # windows_terminal_profile = "PowerShell 7"  # WT profile name for -p flag
+zplex_port = 17732          # TCP port of the local zplex daemon; 0 disables the zplex backend
 
 # ──────────────────────────────────────────────
 # Notification settings
@@ -227,7 +237,8 @@ Zpit supports reloading `config.toml` while the TUI is running. Config fields fa
 | `language` | Calls `locale.SetLanguage()` |
 | `notification.*` | Calls `notifier.UpdateConfig()` |
 | `worktree.poll_seconds` / `pr_poll_seconds` / `max_review_rounds` | Calls `wtManager.UpdateConfig()` |
-| `terminal.*` | Updates cfg; takes effect on the next agent launch |
+| `terminal.*` (including `zplex_port`) | Updates cfg; takes effect on the next agent launch. A `zplex_port` change redirects subsequent launches to the new daemon address without restart. |
+| `auto_close_after_done` | Read at PASS-handling time; changing it mid-cycle affects the current slot's cleanup decision. |
 | `agent_models.*` | Updates cfg; takes effect on the next agent launch (already-running sessions keep the model from their original launch) |
 | per-project `channel_enabled` | Dynamically subscribe/unsubscribe from the EventBus |
 | per-project `channel_listen` | Dynamically manage cross-project subscriptions |

--- a/docs/architecture/07-worktree-and-loop.md
+++ b/docs/architecture/07-worktree-and-loop.md
@@ -145,20 +145,35 @@ Building, testing, reviewing, opening PRs, and updating tracker status are all t
 │  │                                                              │
 │  │ 5. Launch coding agent (new terminal, visible)              │
 │  │    working directory = worktree path, ZPIT_AGENT=1          │
+│  │    zplex sessions: POST agent_state="active", role=<role>   │
+│  │    session ref ({PID, zplex_id, role}) appended to slot     │
 │  │                                                              │
 │  │ 6. Poll issue labels (GetIssue every 10 seconds)            │
 │  │    "review" label detected = coding agent finished          │
-│  │    (label-driven, not PID-driven; terminal stays open)      │
+│  │    (label-driven, not PID-driven)                           │
+│  │    PATCH agent_state="done" for the coder zplex session     │
 │  │                                                              │
 │  │ 7. Launch reviewer agent (same worktree, read-only)         │
+│  │    zplex sessions: POST agent_state="active", role=reviewer  │
+│  │    session ref appended to slot's accumulated list          │
 │  │                                                              │
 │  │ 8. Poll issue labels                                        │
-│  │    ├─ ai-review → PASS → wait for PR merge                 │
+│  │    ├─ ai-review → PASS                                      │
+│  │    │  PATCH reviewer agent_state="done"                     │
+│  │    │  auto_close_after_done=true → kill ALL sessions in     │
+│  │    │    the slot's accumulated session-reference list        │
+│  │    │    (KillWithZeroExit + parent-shell kill; zplex panels  │
+│  │    │    removed by daemon's process-exit watcher)            │
+│  │    │  → wait for PR merge                                   │
 │  │    ├─ needs-changes → NEEDS CHANGES                         │
+│  │    │  PATCH reviewer agent_state="done"                     │
 │  │    │  └─ round < max_review_rounds?                         │
 │  │    │     ├─ yes → write revision prompt, rerun coding agent │
+│  │    │     │        new POST with agent_state="active"         │
 │  │    │     └─ no  → NeedsHuman state, notify for intervention │
 │  │    └─ label unchanged → continue polling                     │
+│  │    Permission-signal scanner: PATCH agent_state="waiting"   │
+│  │    when a session is blocked; "active" when it unblocks      │
 │  │                                                              │
 │  │ 9. PR merged detected → clean up worktree + branch          │
 │  │    + sync local base branch (git fetch origin <base>:<base>)│
@@ -168,6 +183,26 @@ Building, testing, reviewing, opening PRs, and updating tracker status are all t
 │  │                                                              │
 │  └──────────────────────────────────────────────────────────────┘
 ```
+
+### agent_state Sync
+
+When sessions are launched through the zplex backend, zpit keeps the zplex daemon in sync about
+agent progress. Sync is **best-effort and fire-and-forget** — it never blocks the loop and is
+never retried on failure. Sessions launched via the wt/tmux fallback have an empty zplex session
+ID and are silently skipped.
+
+| Event | PATCH agent_state value |
+|---|---|
+| Session launched as a slot agent | `"active"` (sent in the initial POST) |
+| Permission-signal scanner detects a blocked session | `"waiting"` |
+| Blocked session leaves the permission state | `"active"` |
+| Slot transitions out of `SlotCoding` (coder finished) | `"done"` |
+| Slot transitions out of `SlotReviewing` on PASS or needs-changes | `"done"` |
+| Revision relaunch | new POST with `agent_state: "active"` (new session) |
+
+Valid `agent_state` values: `""` (non-agent sessions) | `"active"` | `"waiting"` | `"done"`.
+
+Plain sessions (lazygit, `claude` update, manual launches) POST empty `role` and `agent_state`.
 
 ---
 
@@ -221,6 +256,13 @@ This design prevents the bug where "a nil return path in a handler silently kill
 The `Slot` struct tracks each issue's position in the pipeline:
 
 ```go
+// SessionRef records a launched session for auto-close and agent_state sync.
+type SessionRef struct {
+    PID      int    // OS process ID (used by KillWithZeroExit)
+    ZplexID  string // zplex session ID for PATCH; empty on wt/tmux fallback
+    Role     string // agent role string
+}
+
 type Slot struct {
     ProjectID    string
     IssueID      string
@@ -229,12 +271,30 @@ type Slot struct {
     BaseBranch   string    // PR target branch
     WorktreePath string
     State        SlotState
-    ReviewRound  int       // 0-based; incremented on NEEDS CHANGES
+    ReviewRound  int         // 0-based; incremented on NEEDS CHANGES
     Error        error
-    SessionPID   int
-    LaunchedAt   int64     // unix timestamp
+    Sessions     []SessionRef // accumulated across all review rounds (coder + reviewer)
+    LaunchedAt   int64        // unix timestamp
 }
 ```
+
+`Sessions` accumulates session references across all review rounds instead of overwriting a single
+PID. This enables `auto_close_after_done` to kill the full set of coder + reviewer terminals when
+a slot's review PASSES.
+
+### auto_close_after_done
+
+When `auto_close_after_done = true` (global config, default true) and a slot's reviewer produces
+an `ai-review` PASS verdict, zpit kills **every session** recorded in `Slot.Sessions` using the
+existing backend-agnostic kill path (`KillWithZeroExit` + parent-shell kill). For zplex sessions
+the daemon's process-exit watcher removes the panels. A `needs-changes` verdict **never** triggers
+closing. Only slot-launched sessions are recorded, so clarifier / efficiency / desktop / manual
+sessions are never auto-closed.
+
+**⚠️ Changed invariant:** Previously the loop never killed agent terminals. This invariant is now
+amended: **the loop kills a slot's own terminals after review PASS when `auto_close_after_done` is
+enabled.** The rationale: transcript history is recoverable with external tools, and orchestrator
+terminals show little detail since work is delegated to subagents.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,9 @@ const (
 
 	defaultBrokerPort = 17731
 
+	defaultZplexPort          = 17732
+	defaultAutoCloseAfterDone = true
+
 	defaultSSHPort               = 2200
 	defaultSSHHost               = "0.0.0.0"
 	defaultSSHHostKeyPath        = "~/.zpit/ssh/host_ed25519"
@@ -39,16 +42,17 @@ const (
 
 // Config is the top-level configuration loaded from config.toml.
 type Config struct {
-	Language     string             `toml:"language"`
-	BrokerPort   int                `toml:"broker_port"`
-	ZpitBin      string             `toml:"zpit_bin"`
-	Terminal     TerminalConfig     `toml:"terminal"`
-	Notification NotificationConfig `toml:"notification"`
-	Worktree     WorktreeConfig     `toml:"worktree"`
-	SSH          SSHConfig          `toml:"ssh"`
-	AgentModels  AgentModelsConfig  `toml:"agent_models"`
-	Providers    ProvidersConfig    `toml:"providers"`
-	Projects     []ProjectConfig    `toml:"projects"`
+	Language            string             `toml:"language"`
+	BrokerPort          int                `toml:"broker_port"`
+	ZpitBin             string             `toml:"zpit_bin"`
+	AutoCloseAfterDone  bool               `toml:"auto_close_after_done"`
+	Terminal            TerminalConfig     `toml:"terminal"`
+	Notification        NotificationConfig `toml:"notification"`
+	Worktree            WorktreeConfig     `toml:"worktree"`
+	SSH                 SSHConfig          `toml:"ssh"`
+	AgentModels         AgentModelsConfig  `toml:"agent_models"`
+	Providers           ProvidersConfig    `toml:"providers"`
+	Projects            []ProjectConfig    `toml:"projects"`
 }
 
 // AgentModelsConfig holds the --model value passed to Claude Code for each
@@ -78,6 +82,7 @@ type TerminalConfig struct {
 	WindowsMode            string `toml:"windows_mode"`             // "new_tab" | "new_window"
 	TmuxMode               string `toml:"tmux_mode"`                // "new_window" | "new_pane"
 	WindowsTerminalProfile string `toml:"windows_terminal_profile"` // WT profile name for -p flag
+	ZplexPort              int    `toml:"zplex_port"`               // TCP port for the zplex backend; 0 disables
 }
 
 type NotificationConfig struct {
@@ -176,10 +181,15 @@ const configTemplate = `# Zpit Configuration
 # If omitted, falls back to os.Executable().
 # zpit_bin = "/usr/local/bin/zpit"
 
+# auto_close_after_done: when true, zpit kills a slot's terminal panels after
+# the reviewer issues a PASS (review done). Set to false to keep panels open.
+auto_close_after_done = true
+
 [terminal]
 windows_mode = "new_tab"    # new_tab | new_window
 tmux_mode = "new_window"    # new_window | new_pane
 # windows_terminal_profile = "PowerShell 7"  # WT profile name for -p flag and auto shell detection
+zplex_port = 17732           # TCP port for the zplex launcher backend; 0 disables the zplex backend
 
 [notification]
 tui_alert = true
@@ -266,11 +276,11 @@ func WriteTemplate(path string) error {
 // Load reads and parses the TOML config file.
 func Load(path string) (*Config, error) {
 	var cfg Config
-	_, err := toml.DecodeFile(path, &cfg)
+	md, err := toml.DecodeFile(path, &cfg)
 	if err != nil {
 		return nil, fmt.Errorf("loading config from %s: %w", path, err)
 	}
-	applyDefaults(&cfg)
+	applyDefaults(&cfg, md)
 	return &cfg, nil
 }
 
@@ -348,6 +358,9 @@ func Diff(old, new *Config) ConfigDiff {
 	}
 	if old.Terminal != new.Terminal {
 		diff.HotReload = append(diff.HotReload, "terminal")
+	}
+	if old.AutoCloseAfterDone != new.AutoCloseAfterDone {
+		diff.HotReload = append(diff.HotReload, "auto_close_after_done")
 	}
 	if old.AgentModels != new.AgentModels {
 		diff.HotReload = append(diff.HotReload, "agent_models")
@@ -487,18 +500,24 @@ func stringSliceEqual(a, b []string) bool {
 	return true
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *Config, md toml.MetaData) {
 	if cfg.Language == "" {
 		cfg.Language = "en"
 	}
 	if cfg.BrokerPort == 0 {
 		cfg.BrokerPort = defaultBrokerPort
 	}
+	if !md.IsDefined("auto_close_after_done") {
+		cfg.AutoCloseAfterDone = defaultAutoCloseAfterDone
+	}
 	if cfg.Terminal.WindowsMode == "" {
 		cfg.Terminal.WindowsMode = defaultWindowsMode
 	}
 	if cfg.Terminal.TmuxMode == "" {
 		cfg.Terminal.TmuxMode = defaultTmuxMode
+	}
+	if !md.IsDefined("terminal", "zplex_port") {
+		cfg.Terminal.ZplexPort = defaultZplexPort
 	}
 	if cfg.Worktree.MaxPerProject == 0 {
 		cfg.Worktree.MaxPerProject = defaultMaxPerProject

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,12 @@ func TestLoad(t *testing.T) {
 	if cfg.Terminal.TmuxMode != "new_window" {
 		t.Errorf("TmuxMode = %q, want %q", cfg.Terminal.TmuxMode, "new_window")
 	}
+	if cfg.Terminal.ZplexPort != 17732 {
+		t.Errorf("ZplexPort = %d, want 17732", cfg.Terminal.ZplexPort)
+	}
+	if !cfg.AutoCloseAfterDone {
+		t.Error("AutoCloseAfterDone should be true")
+	}
 
 	// Notification
 	if !cfg.Notification.TUIAlert {
@@ -399,4 +405,92 @@ func containsAll(s string, parts ...string) bool {
 		}
 	}
 	return true
+}
+
+// TestZplexPortAndAutoCloseDefaults verifies that omitting both fields from the
+// config file loads them with their coded defaults (AC-1).
+func TestZplexPortAndAutoCloseDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// Deliberately omit zplex_port and auto_close_after_done.
+	content := "[terminal]\nwindows_mode = \"new_tab\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Terminal.ZplexPort != defaultZplexPort {
+		t.Errorf("ZplexPort = %d, want %d (default)", cfg.Terminal.ZplexPort, defaultZplexPort)
+	}
+	if !cfg.AutoCloseAfterDone {
+		t.Errorf("AutoCloseAfterDone = false, want true (default)")
+	}
+}
+
+// TestZplexPortAndAutoCloseExplicitZero verifies that explicit zero/false values
+// are not overridden by defaults (AC-1).
+func TestZplexPortAndAutoCloseExplicitZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// Explicitly set zplex_port = 0 and auto_close_after_done = false.
+	content := "auto_close_after_done = false\n[terminal]\nzplex_port = 0\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Terminal.ZplexPort != 0 {
+		t.Errorf("ZplexPort = %d, want 0 (explicit disable)", cfg.Terminal.ZplexPort)
+	}
+	if cfg.AutoCloseAfterDone {
+		t.Errorf("AutoCloseAfterDone = true, want false (explicit)")
+	}
+}
+
+// TestZplexPortAndAutoCloseDiff_HotReload verifies that both fields are
+// classified as hot-reload (not restart-required) by Diff (AC-14).
+func TestZplexPortAndAutoCloseDiff_HotReload(t *testing.T) {
+	cases := []struct {
+		name string
+		old  *Config
+		new  *Config
+		want string // expected entry in HotReload
+	}{
+		{
+			name: "zplex_port_change",
+			old:  &Config{Terminal: TerminalConfig{ZplexPort: 17732}},
+			new:  &Config{Terminal: TerminalConfig{ZplexPort: 0}},
+			want: "terminal",
+		},
+		{
+			name: "auto_close_after_done_change",
+			old:  &Config{AutoCloseAfterDone: true},
+			new:  &Config{AutoCloseAfterDone: false},
+			want: "auto_close_after_done",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := Diff(tc.old, tc.new)
+			foundHot := false
+			for _, f := range d.HotReload {
+				if f == tc.want {
+					foundHot = true
+					break
+				}
+			}
+			if !foundHot {
+				t.Errorf("%s change should be in HotReload as %q; got HotReload=%v", tc.name, tc.want, d.HotReload)
+			}
+			for _, f := range d.RestartRequired {
+				if f == tc.want || f == "terminal" {
+					t.Errorf("%s change must NOT be in RestartRequired; got RestartRequired=%v", tc.name, d.RestartRequired)
+				}
+			}
+		})
+	}
 }

--- a/internal/locale/en.go
+++ b/internal/locale/en.go
@@ -255,4 +255,8 @@ var en = map[Key]string{
 	KeyDesktopAlreadyRunning:   "A desktop agent is already running (PID %d). Kill it first.",
 	KeyDesktopLaunching:        "A desktop agent is launching. Wait for it to finish starting up.",
 	KeyDesktopLinuxUnsupported: "Desktop agent is not supported on Linux (computer-use-mcp does not support Linux).",
+
+	// zplex backend
+	KeyZplexLaunched:   "Launched in zplex panel",
+	KeyZplexSwitchHint: "zplex panel",
 }

--- a/internal/locale/keys.go
+++ b/internal/locale/keys.go
@@ -256,4 +256,8 @@ const (
 	KeyDesktopAlreadyRunning   Key = "desktop_already_running"
 	KeyDesktopLaunching        Key = "desktop_launching"
 	KeyDesktopLinuxUnsupported Key = "desktop_linux_unsupported"
+
+	// zplex backend
+	KeyZplexLaunched   Key = "zplex_launched"
+	KeyZplexSwitchHint Key = "zplex_switch_hint"
 )

--- a/internal/locale/zh_tw.go
+++ b/internal/locale/zh_tw.go
@@ -255,4 +255,8 @@ var zhTW = map[Key]string{
 	KeyDesktopAlreadyRunning:   "已有桌面 Agent 在執行 (PID %d)，請先關閉。",
 	KeyDesktopLaunching:        "桌面 Agent 啟動中，請稍候。",
 	KeyDesktopLinuxUnsupported: "桌面 Agent 不支援 Linux (computer-use-mcp 不支援 Linux)。",
+
+	// zplex 後端
+	KeyZplexLaunched:   "已在 zplex 面板啟動",
+	KeyZplexSwitchHint: "zplex 面板",
 }

--- a/internal/loop/types.go
+++ b/internal/loop/types.go
@@ -56,6 +56,14 @@ func (s SlotState) String() string {
 	}
 }
 
+// SessionRef records one launched agent session belonging to a slot.
+// ZplexSessionID is empty when the session was launched via the wt/tmux fallback.
+type SessionRef struct {
+	PID            int
+	ZplexSessionID string
+	Role           string // "coder" or "reviewer"
+}
+
 // Slot tracks a single issue through the automation pipeline.
 type Slot struct {
 	ProjectID    string
@@ -69,7 +77,21 @@ type Slot struct {
 	ReviewRound  int // 0-based; incremented on each NEEDS CHANGES retry
 	Error        error
 	SessionPID   int
-	LaunchedAt   int64 // unix timestamp captured just before agent launch
+	LaunchedAt   int64         // unix timestamp captured just before agent launch
+	Sessions     []SessionRef  // accumulated across review rounds — appended per coder/reviewer launch, never overwritten
+}
+
+// AddSession appends a new SessionRef to the slot's session list.
+func (s *Slot) AddSession(ref SessionRef) { s.Sessions = append(s.Sessions, ref) }
+
+// LatestSessionByRole returns the most recently appended session for the given role.
+func (s *Slot) LatestSessionByRole(role string) (SessionRef, bool) {
+	for i := len(s.Sessions) - 1; i >= 0; i-- {
+		if s.Sessions[i].Role == role {
+			return s.Sessions[i], true
+		}
+	}
+	return SessionRef{}, false
 }
 
 // LoopState tracks per-project loop status.

--- a/internal/platform/detect.go
+++ b/internal/platform/detect.go
@@ -14,6 +14,7 @@ const (
 	EnvWSLTmux
 	EnvLinuxTmux
 	EnvUnknown
+	EnvZplex
 )
 
 func (e Environment) String() string {
@@ -24,6 +25,10 @@ func (e Environment) String() string {
 		return "WSL"
 	case EnvLinuxTmux:
 		return "Linux (tmux)"
+	case EnvUnknown:
+		return "Unknown"
+	case EnvZplex:
+		return "zplex"
 	default:
 		return "Unknown"
 	}

--- a/internal/platform/detect_test.go
+++ b/internal/platform/detect_test.go
@@ -84,6 +84,7 @@ func TestEnvironment_String(t *testing.T) {
 		{EnvWSLTmux, "WSL"},
 		{EnvLinuxTmux, "Linux (tmux)"},
 		{EnvUnknown, "Unknown"},
+		{EnvZplex, "zplex"},
 	}
 	for _, tt := range tests {
 		if got := tt.env.String(); got != tt.want {

--- a/internal/terminal/launcher.go
+++ b/internal/terminal/launcher.go
@@ -8,22 +8,49 @@ import (
 
 	"github.com/zac15987/zpit/internal/config"
 	"github.com/zac15987/zpit/internal/platform"
+	"github.com/zac15987/zpit/internal/zplex"
 )
 
 // LaunchResult contains info about a launched terminal session.
 type LaunchResult struct {
-	Env        platform.Environment
-	Command    string
-	Args       []string
-	SwitchHint string
-	Warnings   []string // non-fatal warnings (e.g. WT profile resolution failures)
+	Env            platform.Environment
+	Command        string
+	Args           []string
+	SwitchHint     string
+	Warnings       []string // non-fatal warnings (e.g. WT profile resolution failures)
+	ZplexSessionID string   // non-empty only on the zplex backend path
+}
+
+// SessionMeta carries loop/project metadata passed to the zplex POST body.
+type SessionMeta struct {
+	ProjectID string
+	IssueID   string
+}
+
+// zplexClient probes the zplex backend and returns a ready client, or nil.
+// It makes AT MOST one HTTP call (Health) and ZERO when port is 0.
+// zplex failures are best-effort: callers fall back to wt/tmux on nil.
+func zplexClient(cfg config.TerminalConfig) *zplex.Client {
+	if cfg.ZplexPort <= 0 {
+		return nil
+	}
+	c := zplex.New(cfg.ZplexPort)
+	if c.Health() != nil {
+		return nil
+	}
+	return c
 }
 
 // LaunchClaude opens a new terminal window/tab and runs claude in the project directory.
 func LaunchClaude(project config.ProjectConfig, cfg config.TerminalConfig, extraArgs ...string) (*LaunchResult, error) {
-	env := platform.Detect()
 	projectPath := platform.ResolvePath(project.Path.Windows, project.Path.WSL)
 
+	if c := zplexClient(cfg); c != nil {
+		return launchClaudeZplex(c, cfg, project.Name, projectPath,
+			SessionMeta{ProjectID: project.ID}, extraArgs)
+	}
+
+	env := platform.Detect()
 	switch env {
 	case platform.EnvWindowsTerminal:
 		return launchWindows(project, cfg, projectPath, extraArgs)
@@ -36,9 +63,13 @@ func LaunchClaude(project config.ProjectConfig, cfg config.TerminalConfig, extra
 
 // LaunchClaudeInDir opens Claude Code in a new terminal with a custom working directory.
 // Used by the loop engine to launch agents in worktree directories.
-func LaunchClaudeInDir(workDir, tabTitle string, cfg config.TerminalConfig, extraArgs ...string) (*LaunchResult, error) {
-	env := platform.Detect()
+// meta carries project/issue IDs for zplex session metadata; pass SessionMeta{} for non-loop launches.
+func LaunchClaudeInDir(workDir, tabTitle string, cfg config.TerminalConfig, meta SessionMeta, extraArgs ...string) (*LaunchResult, error) {
+	if c := zplexClient(cfg); c != nil {
+		return launchClaudeZplex(c, cfg, tabTitle, workDir, meta, extraArgs)
+	}
 
+	env := platform.Detect()
 	switch env {
 	case platform.EnvWindowsTerminal:
 		return launchWindowsInDir(tabTitle, cfg, workDir, extraArgs)
@@ -52,6 +83,10 @@ func LaunchClaudeInDir(workDir, tabTitle string, cfg config.TerminalConfig, extr
 // LaunchLazygit opens lazygit in a new terminal with a custom working directory.
 // Does NOT go through the ZPIT_AGENT hook wrapper — lazygit is a plain user tool.
 func LaunchLazygit(workDir, tabTitle string, cfg config.TerminalConfig) (*LaunchResult, error) {
+	if c := zplexClient(cfg); c != nil {
+		return launchLazygitZplex(c, cfg, tabTitle, workDir)
+	}
+
 	env := platform.Detect()
 	switch env {
 	case platform.EnvWindowsTerminal:
@@ -66,6 +101,10 @@ func LaunchLazygit(workDir, tabTitle string, cfg config.TerminalConfig) (*Launch
 // LaunchClaudeUpdate runs `claude update` in a new terminal and keeps the window
 // open after the command exits so the user can read the result.
 func LaunchClaudeUpdate(cfg config.TerminalConfig) (*LaunchResult, error) {
+	if c := zplexClient(cfg); c != nil {
+		return launchClaudeUpdateZplex(c, cfg)
+	}
+
 	env := platform.Detect()
 	switch env {
 	case platform.EnvWindowsTerminal:

--- a/internal/terminal/launcher_test.go
+++ b/internal/terminal/launcher_test.go
@@ -2,10 +2,16 @@ package terminal
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/zac15987/zpit/internal/config"
 )
 
 func init() {
@@ -563,5 +569,46 @@ func TestResolveShellExe_CachesLookup(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("expected exePathLookup to be called once, got %d", calls)
+	}
+}
+
+// --- zplex dispatch fallback gate tests (AC-15 a/b) ---
+
+// TestZplexClientGate_ZeroPortReturnsNil verifies that zplexClient returns nil
+// (and issues zero HTTP requests) when ZplexPort == 0.
+// A live counting server is started but must receive no requests.
+func TestZplexClientGate_ZeroPortReturnsNil(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := config.TerminalConfig{ZplexPort: 0}
+	c := zplexClient(cfg)
+	if c != nil {
+		t.Errorf("expected nil client for ZplexPort=0, got non-nil")
+	}
+	if requests != 0 {
+		t.Errorf("expected 0 HTTP requests for ZplexPort=0, got %d", requests)
+	}
+}
+
+// TestZplexClientGate_HealthFailReturnsNil verifies that zplexClient returns nil
+// when the health check returns a non-200 status, causing fallback to wt/tmux.
+func TestZplexClientGate_HealthFailReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+
+	cfg := config.TerminalConfig{ZplexPort: port}
+	c := zplexClient(cfg)
+	if c != nil {
+		t.Errorf("expected nil client when health check fails, got non-nil — entry points must fall back to wt/tmux")
 	}
 }

--- a/internal/terminal/launcher_zplex.go
+++ b/internal/terminal/launcher_zplex.go
@@ -1,0 +1,121 @@
+// Package terminal — zplex backend launch functions.
+// No build tags: pure HTTP, compiles on all OSes.
+package terminal
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/zac15987/zpit/internal/config"
+	"github.com/zac15987/zpit/internal/platform"
+	"github.com/zac15987/zpit/internal/zplex"
+)
+
+// launchClaudeZplex creates a claude session on the zplex daemon.
+//
+// The `env` field in the POST body is set to append(os.Environ(), "ZPIT_AGENT=1",
+// "ZPIT_AGENT_TYPE=<role>") if and only if needsAgentEnv(extraArgs) == true.
+// For all other sessions the env field is omitted (nil).
+// The zpit-env / zpit-exit wrapper scripts are NOT referenced here.
+func launchClaudeZplex(c *zplex.Client, cfg config.TerminalConfig, title, cwd string, meta SessionMeta, extraArgs []string) (*LaunchResult, error) {
+	full := buildClaudeArgs(extraArgs) // ["claude", ...]; honors --channel-enabled rewrite
+	shell := full[0]
+	args := full[1:]
+
+	role := getAgentRole(extraArgs)
+	agentState := ""
+	if role != "" {
+		agentState = "active"
+	}
+
+	var env []string
+	if needsAgentEnv(extraArgs) {
+		env = append(os.Environ(), "ZPIT_AGENT=1", "ZPIT_AGENT_TYPE="+role)
+	}
+
+	req := zplex.CreateSessionRequest{
+		Shell:      shell,
+		Title:      title,
+		Args:       args,
+		Cwd:        cwd,
+		Env:        env,
+		Source:     "zpit",
+		ProjectID:  meta.ProjectID,
+		IssueID:    meta.IssueID,
+		Role:       role,
+		AgentState: agentState,
+	}
+
+	id, err := c.CreateSession(req)
+	if err != nil {
+		return nil, fmt.Errorf("zplex create session: %w", err)
+	}
+
+	return &LaunchResult{
+		Env:            platform.EnvZplex,
+		Command:        shell,
+		Args:           args,
+		ZplexSessionID: id,
+		SwitchHint:     title,
+	}, nil
+}
+
+// launchLazygitZplex creates a lazygit session on the zplex daemon.
+// No env, no role/agent_state per AC-11.
+func launchLazygitZplex(c *zplex.Client, _ config.TerminalConfig, title, workDir string) (*LaunchResult, error) {
+	req := zplex.CreateSessionRequest{
+		Shell:  "lazygit",
+		Title:  title,
+		Cwd:    workDir,
+		Source: "zpit",
+	}
+
+	id, err := c.CreateSession(req)
+	if err != nil {
+		return nil, fmt.Errorf("zplex create session: %w", err)
+	}
+
+	return &LaunchResult{
+		Env:            platform.EnvZplex,
+		Command:        "lazygit",
+		ZplexSessionID: id,
+		SwitchHint:     title,
+	}, nil
+}
+
+// launchClaudeUpdateZplex creates a claude update session on the zplex daemon.
+// Uses the same command string as the wt/tmux variants per GOOS so the panel
+// persists until keypress, then closes by process exit.
+// No env, no role/agent_state per AC-11.
+func launchClaudeUpdateZplex(c *zplex.Client, _ config.TerminalConfig) (*LaunchResult, error) {
+	var shell string
+	var args []string
+
+	if platform.IsWindows() {
+		shell = "cmd"
+		args = []string{"/c", "claude update & pause"}
+	} else {
+		shell = "sh"
+		args = []string{"-c", `claude update; read -n1 -r -p "Press any key to close..."`}
+	}
+
+	req := zplex.CreateSessionRequest{
+		Shell:  shell,
+		Title:  "claude update",
+		Args:   args,
+		Source: "zpit",
+	}
+
+	id, err := c.CreateSession(req)
+	if err != nil {
+		return nil, fmt.Errorf("zplex create session: %w", err)
+	}
+
+	return &LaunchResult{
+		Env:            platform.EnvZplex,
+		Command:        shell,
+		Args:           args,
+		ZplexSessionID: id,
+		SwitchHint:     "claude update",
+	}, nil
+}

--- a/internal/terminal/launcher_zplex_test.go
+++ b/internal/terminal/launcher_zplex_test.go
@@ -1,0 +1,462 @@
+// Package terminal — white-box tests for the zplex backend launch functions.
+// Tests use httptest.NewServer to stand up a fake zplex daemon and verify:
+//   (a) fallback gate: zplexClient returns nil when health check fails or port is 0
+//   (b) zero HTTP requests when ZplexPort == 0
+//   (c) POST body contents for each entry-point variant
+package terminal
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/zac15987/zpit/internal/config"
+	"github.com/zac15987/zpit/internal/platform"
+)
+
+// zplexTestServer stands up a fake zplex daemon.
+// It responds 200 on GET /api/health and 201 on POST /api/sessions with
+// {"id":"sess-1","ws_url":"/ws/sess-1"}, capturing the last POST body.
+type zplexTestServer struct {
+	srv     *httptest.Server
+	lastReq []byte
+	reqCount atomic.Int64
+}
+
+func newZplexTestServer(t *testing.T) *zplexTestServer {
+	t.Helper()
+	ts := &zplexTestServer{}
+	ts.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.reqCount.Add(1)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/sessions":
+			var buf []byte
+			if r.Body != nil {
+				buf = make([]byte, 0, 512)
+				tmp := make([]byte, 512)
+				for {
+					n, err := r.Body.Read(tmp)
+					buf = append(buf, tmp[:n]...)
+					if err != nil {
+						break
+					}
+				}
+			}
+			ts.lastReq = buf
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"sess-1","ws_url":"/ws/sess-1"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(ts.srv.Close)
+	return ts
+}
+
+// port returns the TCP port of the test server.
+func (ts *zplexTestServer) port() int {
+	u, _ := url.Parse(ts.srv.URL)
+	p, _ := strconv.Atoi(u.Port())
+	return p
+}
+
+// decodeLastBody decodes the captured POST body into a map.
+func (ts *zplexTestServer) decodeLastBody(t *testing.T) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(ts.lastReq, &m); err != nil {
+		t.Fatalf("decode POST body: %v (raw: %s)", err, ts.lastReq)
+	}
+	return m
+}
+
+// newFailingHealthServer creates a test server that always returns 500 on /api/health.
+func newFailingHealthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// --- (a) Fallback gate tests ---
+
+// TestZplexClient_HealthFail verifies that zplexClient returns nil when the
+// server responds with a non-200 status on GET /api/health.
+func TestZplexClient_HealthFail(t *testing.T) {
+	srv := newFailingHealthServer(t)
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+
+	cfg := config.TerminalConfig{ZplexPort: port}
+	c := zplexClient(cfg)
+	if c != nil {
+		t.Errorf("zplexClient expected nil on health-fail server, got non-nil")
+	}
+}
+
+// TestZplexClient_UnreachablePort verifies that zplexClient returns nil when the
+// port is unreachable (connection refused / timeout).
+func TestZplexClient_UnreachablePort(t *testing.T) {
+	// Use port 1 — a well-known reserved port that is always closed on localhost.
+	// The 500 ms health timeout will expire quickly.
+	cfg := config.TerminalConfig{ZplexPort: 1}
+	c := zplexClient(cfg)
+	if c != nil {
+		t.Errorf("zplexClient expected nil for unreachable port, got non-nil")
+	}
+}
+
+// --- (b) Zero-port: no HTTP requests ---
+
+// TestZplexClient_ZeroPort verifies that zplexClient returns nil immediately
+// and makes ZERO HTTP requests when ZplexPort == 0.
+func TestZplexClient_ZeroPort(t *testing.T) {
+	var reqCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reqCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := config.TerminalConfig{ZplexPort: 0}
+	c := zplexClient(cfg)
+	if c != nil {
+		t.Errorf("zplexClient with ZplexPort=0 expected nil, got non-nil")
+	}
+	if n := reqCount.Load(); n != 0 {
+		t.Errorf("expected zero HTTP requests for ZplexPort=0, got %d", n)
+	}
+}
+
+// --- (c) POST body tests ---
+
+// makeProject returns a minimal ProjectConfig for POST body tests.
+func makeProject() config.ProjectConfig {
+	return config.ProjectConfig{
+		Name: "Proj",
+		ID:   "proj1",
+		Path: config.ProjectPathConfig{
+			Windows: "D:/x",
+			WSL:     "/x",
+		},
+	}
+}
+
+// TestZplexPostBody_AgentWithEnvInjection verifies the POST body for an agent
+// session that requires env injection (needsAgentEnv == true, e.g. "clarifier").
+// AC-15(c): body.source=="zpit", body.title=="Proj", body.project_id=="proj1",
+// body.role=="clarifier", body.agent_state=="active",
+// body.env contains "ZPIT_AGENT=1" and "ZPIT_AGENT_TYPE=clarifier",
+// body.shell=="claude"; result.Env==EnvZplex, result.ZplexSessionID=="sess-1".
+func TestZplexPostBody_AgentWithEnvInjection(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+	project := makeProject()
+
+	result, err := LaunchClaude(project, cfg, "--agent", "clarifier")
+	if err != nil {
+		t.Fatalf("LaunchClaude: %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "source", "zpit", body["source"])
+	assertEqual(t, "title", "Proj", body["title"])
+	assertEqual(t, "project_id", "proj1", body["project_id"])
+	assertEqual(t, "role", "clarifier", body["role"])
+	assertEqual(t, "agent_state", "active", body["agent_state"])
+	assertEqual(t, "shell", "claude", body["shell"])
+
+	// env must contain ZPIT_AGENT=1 and ZPIT_AGENT_TYPE=clarifier
+	envList := toStringSlice(t, body["env"])
+	assertContains(t, "env", envList, "ZPIT_AGENT=1")
+	assertContains(t, "env", envList, "ZPIT_AGENT_TYPE=clarifier")
+
+	// result assertions
+	if result.Env != platform.EnvZplex {
+		t.Errorf("result.Env: got %v, want %v", result.Env, platform.EnvZplex)
+	}
+	if result.ZplexSessionID != "sess-1" {
+		t.Errorf("result.ZplexSessionID: got %q, want %q", result.ZplexSessionID, "sess-1")
+	}
+}
+
+// TestZplexPostBody_EfficiencyAgentNoEnv verifies the POST body for the efficiency
+// agent, which must NOT inject env vars (needsAgentEnv == false).
+// AC-15(c): body.role=="efficiency", body.agent_state=="active", body.env absent/empty.
+func TestZplexPostBody_EfficiencyAgentNoEnv(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+	project := makeProject()
+
+	result, err := LaunchClaude(project, cfg, "--agent", "efficiency")
+	if err != nil {
+		t.Fatalf("LaunchClaude (efficiency): %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "role", "efficiency", body["role"])
+	assertEqual(t, "agent_state", "active", body["agent_state"])
+
+	// env must be absent or empty
+	if env, ok := body["env"]; ok && env != nil {
+		envList := toStringSlice(t, env)
+		if len(envList) != 0 {
+			t.Errorf("efficiency agent: expected env absent/empty, got %v", envList)
+		}
+	}
+
+	if result.Env != platform.EnvZplex {
+		t.Errorf("result.Env: got %v, want %v", result.Env, platform.EnvZplex)
+	}
+	if result.ZplexSessionID != "sess-1" {
+		t.Errorf("result.ZplexSessionID: got %q, want %q", result.ZplexSessionID, "sess-1")
+	}
+}
+
+// TestZplexPostBody_DesktopAgentNoEnv verifies the POST body for the desktop
+// agent, which must NOT inject env vars (needsAgentEnv == false).
+func TestZplexPostBody_DesktopAgentNoEnv(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+	project := makeProject()
+
+	_, err := LaunchClaude(project, cfg, "--agent", "desktop")
+	if err != nil {
+		t.Fatalf("LaunchClaude (desktop): %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "role", "desktop", body["role"])
+	assertEqual(t, "agent_state", "active", body["agent_state"])
+
+	// env must be absent or empty
+	if env, ok := body["env"]; ok && env != nil {
+		envList := toStringSlice(t, env)
+		if len(envList) != 0 {
+			t.Errorf("desktop agent: expected env absent/empty, got %v", envList)
+		}
+	}
+}
+
+// TestZplexPostBody_PlainSession verifies the POST body for a plain claude session
+// (no --agent flag).
+// AC-15(c): body.role=="", body.agent_state=="", body.env empty, body.shell=="claude".
+func TestZplexPostBody_PlainSession(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+	project := makeProject()
+
+	result, err := LaunchClaude(project, cfg)
+	if err != nil {
+		t.Fatalf("LaunchClaude (plain): %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "shell", "claude", body["shell"])
+
+	// role and agent_state must be absent (omitempty) or empty string
+	if role, ok := body["role"]; ok && role != "" {
+		t.Errorf("plain session: expected role absent/empty, got %v", role)
+	}
+	if state, ok := body["agent_state"]; ok && state != "" {
+		t.Errorf("plain session: expected agent_state absent/empty, got %v", state)
+	}
+
+	// env must be absent or empty
+	if env, ok := body["env"]; ok && env != nil {
+		envList := toStringSlice(t, env)
+		if len(envList) != 0 {
+			t.Errorf("plain session: expected env absent/empty, got %v", envList)
+		}
+	}
+
+	if result.Env != platform.EnvZplex {
+		t.Errorf("result.Env: got %v, want %v", result.Env, platform.EnvZplex)
+	}
+}
+
+// TestZplexPostBody_Lazygit verifies the POST body for a lazygit session.
+// AC-15(c): body.shell=="lazygit", body.cwd=="D:/work", body.title=="lazygit — Proj",
+// body.source=="zpit", body.env absent/empty, body.role absent/empty,
+// body.agent_state absent/empty.
+func TestZplexPostBody_Lazygit(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+
+	result, err := LaunchLazygit("D:/work", "lazygit — Proj", cfg)
+	if err != nil {
+		t.Fatalf("LaunchLazygit: %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "shell", "lazygit", body["shell"])
+	assertEqual(t, "cwd", "D:/work", body["cwd"])
+	assertEqual(t, "title", "lazygit — Proj", body["title"])
+	assertEqual(t, "source", "zpit", body["source"])
+
+	// env must be absent or empty
+	if env, ok := body["env"]; ok && env != nil {
+		envList := toStringSlice(t, env)
+		if len(envList) != 0 {
+			t.Errorf("lazygit: expected env absent/empty, got %v", envList)
+		}
+	}
+	if role, ok := body["role"]; ok && role != "" {
+		t.Errorf("lazygit: expected role absent/empty, got %v", role)
+	}
+	if state, ok := body["agent_state"]; ok && state != "" {
+		t.Errorf("lazygit: expected agent_state absent/empty, got %v", state)
+	}
+
+	if result.Env != platform.EnvZplex {
+		t.Errorf("result.Env: got %v, want %v", result.Env, platform.EnvZplex)
+	}
+	if result.ZplexSessionID != "sess-1" {
+		t.Errorf("result.ZplexSessionID: got %q, want %q", result.ZplexSessionID, "sess-1")
+	}
+}
+
+// TestZplexPostBody_ClaudeUpdate verifies the POST body for a claude update session.
+// AC-15(c): body.shell is "cmd" on Windows else "sh"; body.title=="claude update";
+// body.source=="zpit"; body.role/agent_state absent/empty.
+// On Windows: body.args == ["/c","claude update & pause"].
+func TestZplexPostBody_ClaudeUpdate(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+
+	result, err := LaunchClaudeUpdate(cfg)
+	if err != nil {
+		t.Fatalf("LaunchClaudeUpdate: %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "title", "claude update", body["title"])
+	assertEqual(t, "source", "zpit", body["source"])
+
+	if role, ok := body["role"]; ok && role != "" {
+		t.Errorf("claude update: expected role absent/empty, got %v", role)
+	}
+	if state, ok := body["agent_state"]; ok && state != "" {
+		t.Errorf("claude update: expected agent_state absent/empty, got %v", state)
+	}
+
+	if runtime.GOOS == "windows" {
+		assertEqual(t, "shell", "cmd", body["shell"])
+		// args must be ["/c", "claude update & pause"]
+		args := toStringSlice(t, body["args"])
+		if len(args) != 2 || args[0] != "/c" || args[1] != "claude update & pause" {
+			t.Errorf("claude update (windows): expected args=[\"/c\",\"claude update & pause\"], got %v", args)
+		}
+	} else {
+		assertEqual(t, "shell", "sh", body["shell"])
+	}
+
+	if result.Env != platform.EnvZplex {
+		t.Errorf("result.Env: got %v, want %v", result.Env, platform.EnvZplex)
+	}
+	if result.ZplexSessionID != "sess-1" {
+		t.Errorf("result.ZplexSessionID: got %q, want %q", result.ZplexSessionID, "sess-1")
+	}
+}
+
+// TestZplexPostBody_LoopMetadata verifies the POST body for a loop-initiated
+// LaunchClaudeInDir call, which carries project_id, issue_id, role, and agent_state.
+// AC-15(c): body.project_id=="proj1", body.issue_id=="42",
+// body.role=="coding", body.agent_state=="active".
+func TestZplexPostBody_LoopMetadata(t *testing.T) {
+	ts := newZplexTestServer(t)
+	cfg := config.TerminalConfig{ZplexPort: ts.port()}
+
+	meta := SessionMeta{ProjectID: "proj1", IssueID: "42"}
+	result, err := LaunchClaudeInDir("D:/wt", "Proj #42", cfg, meta, "--agent", "coding", "init")
+	if err != nil {
+		t.Fatalf("LaunchClaudeInDir: %v", err)
+	}
+
+	body := ts.decodeLastBody(t)
+
+	assertEqual(t, "project_id", "proj1", body["project_id"])
+	assertEqual(t, "issue_id", "42", body["issue_id"])
+	assertEqual(t, "role", "coding", body["role"])
+	assertEqual(t, "agent_state", "active", body["agent_state"])
+
+	if result.Env != platform.EnvZplex {
+		t.Errorf("result.Env: got %v, want %v", result.Env, platform.EnvZplex)
+	}
+	if result.ZplexSessionID != "sess-1" {
+		t.Errorf("result.ZplexSessionID: got %q, want %q", result.ZplexSessionID, "sess-1")
+	}
+}
+
+// --- Test helpers ---
+
+// assertEqual reports a test failure if got != want (string comparison via fmt).
+func assertEqual(t *testing.T, field string, want any, got any) {
+	t.Helper()
+	wantStr := toString(want)
+	gotStr := toString(got)
+	if wantStr != gotStr {
+		t.Errorf("%s: got %q, want %q", field, gotStr, wantStr)
+	}
+}
+
+func toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch s := v.(type) {
+	case string:
+		return s
+	default:
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
+}
+
+// toStringSlice converts a JSON-decoded []any to []string.
+func toStringSlice(t *testing.T, v any) []string {
+	t.Helper()
+	if v == nil {
+		return nil
+	}
+	raw, ok := v.([]any)
+	if !ok {
+		t.Fatalf("toStringSlice: expected []any, got %T (%v)", v, v)
+	}
+	result := make([]string, len(raw))
+	for i, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("toStringSlice[%d]: expected string, got %T", i, item)
+		}
+		result[i] = s
+	}
+	return result
+}
+
+// assertContains checks that the slice contains the expected value.
+func assertContains(t *testing.T, field string, slice []string, expected string) {
+	t.Helper()
+	for _, s := range slice {
+		if s == expected {
+			return
+		}
+	}
+	t.Errorf("%s: expected to contain %q, got %v", field, expected, slice)
+}

--- a/internal/tui/launch.go
+++ b/internal/tui/launch.go
@@ -434,6 +434,9 @@ func (m Model) handleDesktopAgentLaunched(msg DesktopAgentLaunchedMsg) (tea.Mode
 	m.state.NotifyAll()
 	m.state.Unlock()
 
+	if at.ZplexSessionID != "" {
+		m.state.logger.Printf("zplex launch: key=%s role=%s session=%s", trackingKey, "desktop", at.ZplexSessionID)
+	}
 	m.state.logger.Printf("desktop: launched agent=%s (PID pending session discovery)", msg.AgentName)
 	// Kick off active session discovery (same flow as project-scope launches).
 	// Without this, a terminal closed before the 10s periodic scan would leave

--- a/internal/tui/launch.go
+++ b/internal/tui/launch.go
@@ -914,8 +914,12 @@ func (m Model) openSlotPRCmd(slotKey string) (tea.Model, tea.Cmd) {
 // runLazygitCmd returns a tea.Cmd that spawns lazygit in a new terminal.
 func runLazygitCmd(workDir, title string, cfg config.TerminalConfig) tea.Cmd {
 	return func() tea.Msg {
-		if _, err := terminal.LaunchLazygit(workDir, title, cfg); err != nil {
+		result, err := terminal.LaunchLazygit(workDir, title, cfg)
+		if err != nil {
 			return StatusMsg{Text: fmt.Sprintf("lazygit launch failed: %s", err)}
+		}
+		if result != nil && result.Env == platform.EnvZplex {
+			return StatusMsg{Text: locale.T(locale.KeyZplexLaunched)}
 		}
 		return StatusMsg{Text: fmt.Sprintf("Opened lazygit in %s", workDir)}
 	}
@@ -960,8 +964,12 @@ func (m Model) launchSlotLazygitCmd(slotKey string) (tea.Model, tea.Cmd) {
 func (m Model) launchClaudeUpdateCmd() tea.Cmd {
 	cfg := m.state.cfg.Terminal
 	return func() tea.Msg {
-		if _, err := terminal.LaunchClaudeUpdate(cfg); err != nil {
+		result, err := terminal.LaunchClaudeUpdate(cfg)
+		if err != nil {
 			return StatusMsg{Text: fmt.Sprintf("claude update launch failed: %s", err)}
+		}
+		if result != nil && result.Env == platform.EnvZplex {
+			return StatusMsg{Text: locale.T(locale.KeyZplexLaunched)}
 		}
 		return StatusMsg{Text: "Launched claude update"}
 	}

--- a/internal/tui/launch.go
+++ b/internal/tui/launch.go
@@ -426,6 +426,9 @@ func (m Model) handleDesktopAgentLaunched(msg DesktopAgentLaunchedMsg) (tea.Mode
 		State:          watcher.StateUnknown,
 		StateChangedAt: time.Now(),
 	}
+	if msg.Result != nil {
+		at.ZplexSessionID = msg.Result.ZplexSessionID
+	}
 	m.state.activeTerminals[trackingKey] = at
 	m.state.activeDesktopAgent = at
 	m.state.NotifyAll()
@@ -704,7 +707,7 @@ func (m Model) launchFocusClaudeCmd(slotKey string) (tea.Model, tea.Cmd) {
 		}
 		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg,
 			terminal.SessionMeta{ProjectID: focusProjectID, IssueID: issueID}, args...)
-		return LaunchResultMsg{
+		msg := LaunchResultMsg{
 			ProjectID:      focusProjectID,
 			TrackingKey:    trackingKey,
 			WorkDir:        wtPath,
@@ -712,6 +715,10 @@ func (m Model) launchFocusClaudeCmd(slotKey string) (tea.Model, tea.Cmd) {
 			Result:         result,
 			Err:            err,
 		}
+		if result != nil {
+			msg.ZplexSessionID = result.ZplexSessionID
+		}
+		return msg
 	}
 }
 

--- a/internal/tui/launch.go
+++ b/internal/tui/launch.go
@@ -398,7 +398,7 @@ func (m Model) launchDesktopAgentCmd() tea.Cmd {
 			"--mcp-config", mcpConfigPath,
 			"--allowedTools", "Read,Bash,Glob,Grep,mcp__desktop-proxy__*",
 		}
-		result, launchErr := terminal.LaunchClaudeInDir(homeDir, tabTitle, cfg, args...)
+		result, launchErr := terminal.LaunchClaudeInDir(homeDir, tabTitle, cfg, terminal.SessionMeta{}, args...)
 		return DesktopAgentLaunchedMsg{
 			AgentName: agentName,
 			HomeDir:   homeDir,
@@ -702,7 +702,8 @@ func (m Model) launchFocusClaudeCmd(slotKey string) (tea.Model, tea.Cmd) {
 		if channelEnabled {
 			args = append(args, "--channel-enabled")
 		}
-		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg, args...)
+		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg,
+			terminal.SessionMeta{ProjectID: focusProjectID, IssueID: issueID}, args...)
 		return LaunchResultMsg{
 			ProjectID:      focusProjectID,
 			TrackingKey:    trackingKey,

--- a/internal/tui/loop_cmds.go
+++ b/internal/tui/loop_cmds.go
@@ -22,7 +22,59 @@ import (
 	"github.com/zac15987/zpit/internal/terminal"
 	"github.com/zac15987/zpit/internal/tracker"
 	"github.com/zac15987/zpit/internal/worktree"
+	"github.com/zac15987/zpit/internal/zplex"
 )
+
+// zplexPatcher is the minimal interface used for fire-and-forget agent_state sync.
+type zplexPatcher interface{ PatchAgentState(id, state string) error }
+
+// newZplexClient builds the patcher; overridable in tests.
+var newZplexClient = func(port int) zplexPatcher { return zplex.New(port) }
+
+// patchZplexStateCmd issues a fire-and-forget PATCH to update the zplex agent_state.
+// Returns nil when sessionID is empty (wt/tmux fallback — no zplex session).
+func (m Model) patchZplexStateCmd(sessionID, state string) tea.Cmd {
+	if sessionID == "" {
+		return nil
+	}
+	port := m.state.cfg.Terminal.ZplexPort
+	logger := m.state.logger
+	return func() tea.Msg {
+		if port <= 0 {
+			return nil
+		}
+		if err := newZplexClient(port).PatchAgentState(sessionID, state); err != nil {
+			logger.Printf("zplex sync failed: session=%s agent_state=%s err=%v", sessionID, state, err)
+		} else {
+			logger.Printf("zplex sync: session=%s agent_state=%s", sessionID, state)
+		}
+		return nil
+	}
+}
+
+// killSessionFn kills one session's PID (and its parent shell) — overridable in tests.
+var killSessionFn = func(pid int) {
+	if pid <= 0 {
+		return
+	}
+	parentPID, _ := terminal.FindParentShell(pid)
+	_ = terminal.KillWithZeroExit(pid)
+	if parentPID > 0 {
+		terminal.KillProcess(parentPID)
+	}
+}
+
+// autoCloseSlotCmd kills every recorded session PID for the slot.
+func (m Model) autoCloseSlotCmd(projectID, issueID string, pids []int) tea.Cmd {
+	logger := m.state.logger
+	return func() tea.Msg {
+		logger.Printf("auto-close: project=%s issue=%s sessions=%d", projectID, issueID, len(pids))
+		for _, pid := range pids {
+			killSessionFn(pid)
+		}
+		return nil
+	}
+}
 
 // loopPollCmd polls the tracker for todo issues.
 // After filtering for "todo" status, it parses each issue's DEPENDS_ON section,
@@ -481,11 +533,15 @@ func (m Model) loopLaunchCoderCmd(projectID, issueID string) tea.Cmd {
 		}
 		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg,
 			terminal.SessionMeta{ProjectID: projectID, IssueID: issueID}, args...)
-		return LoopAgentLaunchedMsg{
+		msg := LoopAgentLaunchedMsg{
 			ProjectID: projectID, IssueID: issueID,
 			Role: "coder", LaunchedAt: launchedAt,
 			Result: result, Err: err,
 		}
+		if result != nil {
+			msg.ZplexSessionID = result.ZplexSessionID
+		}
+		return msg
 	}
 }
 
@@ -612,11 +668,15 @@ func (m Model) loopWriteAndLaunchReviewerCmd(projectID, issueID string) tea.Cmd 
 		}
 		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg,
 			terminal.SessionMeta{ProjectID: projectID, IssueID: issueID}, args...)
-		return LoopAgentLaunchedMsg{
+		msg := LoopAgentLaunchedMsg{
 			ProjectID: projectID, IssueID: issueID,
 			Role: "reviewer", LaunchedAt: launchedAt,
 			Result: result, Err: err,
 		}
+		if result != nil {
+			msg.ZplexSessionID = result.ZplexSessionID
+		}
+		return msg
 	}
 }
 

--- a/internal/tui/loop_cmds.go
+++ b/internal/tui/loop_cmds.go
@@ -479,7 +479,8 @@ func (m Model) loopLaunchCoderCmd(projectID, issueID string) tea.Cmd {
 		if channelEnabled {
 			args = append(args, "--channel-enabled")
 		}
-		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg, args...)
+		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg,
+			terminal.SessionMeta{ProjectID: projectID, IssueID: issueID}, args...)
 		return LoopAgentLaunchedMsg{
 			ProjectID: projectID, IssueID: issueID,
 			Role: "coder", LaunchedAt: launchedAt,
@@ -609,7 +610,8 @@ func (m Model) loopWriteAndLaunchReviewerCmd(projectID, issueID string) tea.Cmd 
 		if channelEnabled {
 			args = append(args, "--channel-enabled")
 		}
-		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg, args...)
+		result, err := terminal.LaunchClaudeInDir(wtPath, tabTitle, cfg,
+			terminal.SessionMeta{ProjectID: projectID, IssueID: issueID}, args...)
 		return LoopAgentLaunchedMsg{
 			ProjectID: projectID, IssueID: issueID,
 			Role: "reviewer", LaunchedAt: launchedAt,

--- a/internal/tui/loop_handler.go
+++ b/internal/tui/loop_handler.go
@@ -284,6 +284,10 @@ func (m Model) handleLoopAgentLaunched(msg LoopAgentLaunchedMsg) (tea.Model, tea
 		}
 	}
 
+	// Record this session in the slot's accumulated session list. PID is left 0
+	// here — it is resolved at auto-close time from activeTerminals by ZplexSessionID.
+	slot.AddSession(loop.SessionRef{ZplexSessionID: msg.ZplexSessionID, Role: msg.Role})
+
 	if msg.Role == "coder" {
 		slot.State = loop.SlotCoding
 		m.state.logger.Printf("loop: coder launched #%s (round=%d)", msg.IssueID, slot.ReviewRound)
@@ -322,11 +326,18 @@ func (m Model) handleLoopLabelPoll(msg LoopLabelPollMsg) (tea.Model, tea.Cmd) {
 	switch slot.State {
 	case loop.SlotCoding:
 		if hasLabel(msg.Labels, "review") {
+			// Capture coder session ref before state transition (AC-9).
+			coderRef, hasCoder := slot.LatestSessionByRole("coder")
 			slot.State = loop.SlotLaunchingReviewer
 			m.state.logger.Printf("loop: label 'review' found #%s → launching reviewer", msg.IssueID)
 			m.state.NotifyAll()
 			m.state.Unlock()
-			return m, m.loopWriteAndLaunchReviewerCmd(msg.ProjectID, msg.IssueID)
+			var cmds []tea.Cmd
+			cmds = append(cmds, m.loopWriteAndLaunchReviewerCmd(msg.ProjectID, msg.IssueID))
+			if hasCoder {
+				cmds = append(cmds, m.patchZplexStateCmd(coderRef.ZplexSessionID, "done"))
+			}
+			return m, tea.Batch(cmds...)
 		}
 		m.state.Unlock()
 		// Tick handler has already rescheduled.
@@ -336,21 +347,81 @@ func (m Model) handleLoopLabelPoll(msg LoopLabelPollMsg) (tea.Model, tea.Cmd) {
 		if hasLabel(msg.Labels, "ai-review") {
 			project := m.findProject(msg.ProjectID)
 			autoMerge := project != nil && project.AutoMerge
+			autoClose := m.state.cfg.AutoCloseAfterDone
+
+			// Capture reviewer session ref for done-PATCH (AC-9).
+			reviewerRef, hasReviewer := slot.LatestSessionByRole("reviewer")
+
+			// Collect kill PIDs under the lock for auto-close (AC-10).
+			var pids []int
+			if autoClose {
+				for _, ref := range slot.Sessions {
+					pid := ref.PID
+					if pid == 0 && ref.ZplexSessionID != "" {
+						// Resolve live PID from activeTerminals by ZplexSessionID.
+						for _, at := range m.state.activeTerminals {
+							if at.ZplexSessionID == ref.ZplexSessionID {
+								pid = at.SessionPID
+								break
+							}
+						}
+					}
+					if pid == 0 {
+						// Fallback: resolve by worktree path.
+						for _, at := range m.state.activeTerminals {
+							if at.WorkDir == slot.WorktreePath {
+								pid = at.SessionPID
+								break
+							}
+						}
+					}
+					if pid > 0 {
+						pids = append(pids, pid)
+					}
+				}
+			}
+
+			// Capture locals for cmd construction after unlock.
+			projectID := msg.ProjectID
+			issueID := msg.IssueID
+			worktreePath := slot.WorktreePath
+			_ = worktreePath // used in pid resolution above
+
 			if autoMerge {
 				slot.State = loop.SlotAutoMerging
 				m.state.logger.Printf("loop: label 'ai-review' found #%s → auto-merging", msg.IssueID)
 				m.state.NotifyAll()
 				m.state.Unlock()
-				return m, m.loopAutoMergeCmd(msg.ProjectID, msg.IssueID)
+				var cmds []tea.Cmd
+				cmds = append(cmds, m.loopAutoMergeCmd(projectID, issueID))
+				if hasReviewer {
+					cmds = append(cmds, m.patchZplexStateCmd(reviewerRef.ZplexSessionID, "done"))
+				}
+				if autoClose {
+					cmds = append(cmds, m.autoCloseSlotCmd(projectID, issueID, pids))
+				}
+				return m, tea.Batch(cmds...)
 			}
 			slot.State = loop.SlotWaitingPRMerge
 			m.state.logger.Printf("loop: label 'ai-review' found #%s → waiting PR merge", msg.IssueID)
 			m.state.NotifyAll()
 			m.state.Unlock()
-			return m, m.loopSchedulePRPoll(msg.ProjectID, msg.IssueID)
+			var cmds []tea.Cmd
+			cmds = append(cmds, m.loopSchedulePRPoll(projectID, issueID))
+			if hasReviewer {
+				cmds = append(cmds, m.patchZplexStateCmd(reviewerRef.ZplexSessionID, "done"))
+			}
+			if autoClose {
+				cmds = append(cmds, m.autoCloseSlotCmd(projectID, issueID, pids))
+			}
+			return m, tea.Batch(cmds...)
 		}
 		if hasLabel(msg.Labels, "needs-changes") {
 			maxRounds := m.state.cfg.Worktree.MaxReviewRounds
+
+			// Capture reviewer session ref for done-PATCH (AC-9).
+			reviewerRef, hasReviewer := slot.LatestSessionByRole("reviewer")
+
 			if slot.ReviewRound >= maxRounds {
 				slot.State = loop.SlotNeedsHuman
 				m.state.logger.Printf("loop: #%s review rounds exhausted (%d), needs human", msg.IssueID, maxRounds)
@@ -363,6 +434,10 @@ func (m Model) handleLoopLabelPoll(msg LoopLabelPollMsg) (tea.Model, tea.Cmd) {
 				if w := m.state.notifier.ConsumeWarning(); w != "" {
 					m.setStatus(fmt.Sprintf(locale.T(locale.KeySoundFileNotFound), m.state.cfg.Notification.SoundFile))
 				}
+				// No kill on needs-changes (AC-10). Patch reviewer done (AC-9).
+				if hasReviewer {
+					return m, m.patchZplexStateCmd(reviewerRef.ZplexSessionID, "done")
+				}
 				return m, nil
 			}
 			slot.ReviewRound++
@@ -372,6 +447,13 @@ func (m Model) handleLoopLabelPoll(msg LoopLabelPollMsg) (tea.Model, tea.Cmd) {
 			m.state.Unlock()
 			m.setStatus(fmt.Sprintf("Issue #%s needs changes (round %d/%d), re-launching coder",
 				msg.IssueID, slot.ReviewRound, maxRounds))
+			// No kill on needs-changes (AC-10). Patch reviewer done (AC-9).
+			if hasReviewer {
+				return m, tea.Batch(
+					m.loopWriteRevisionAgentCmd(msg.ProjectID, msg.IssueID),
+					m.patchZplexStateCmd(reviewerRef.ZplexSessionID, "done"),
+				)
+			}
 			return m, m.loopWriteRevisionAgentCmd(msg.ProjectID, msg.IssueID)
 		}
 		m.state.Unlock()

--- a/internal/tui/loop_handler.go
+++ b/internal/tui/loop_handler.go
@@ -287,6 +287,10 @@ func (m Model) handleLoopAgentLaunched(msg LoopAgentLaunchedMsg) (tea.Model, tea
 	// Record this session in the slot's accumulated session list. PID is left 0
 	// here — it is resolved at auto-close time from activeTerminals by ZplexSessionID.
 	slot.AddSession(loop.SessionRef{ZplexSessionID: msg.ZplexSessionID, Role: msg.Role})
+	if msg.ZplexSessionID != "" {
+		m.state.logger.Printf("zplex launch: key=%s role=%s session=%s",
+			loop.SlotKey(msg.ProjectID, msg.IssueID), msg.Role, msg.ZplexSessionID)
+	}
 
 	if msg.Role == "coder" {
 		slot.State = loop.SlotCoding

--- a/internal/tui/msg.go
+++ b/internal/tui/msg.go
@@ -18,6 +18,7 @@ type LaunchResultMsg struct {
 	TrackingKey    string // if set, use as activeTerminals key instead of ProjectID
 	WorkDir        string // if set, use for session discovery instead of project path
 	WorktreeBranch string // non-empty when launched in a git worktree (e.g. "feat/19-slug")
+	ZplexSessionID string // zplex session id from the launch; empty on wt/tmux fallback
 	Result         *terminal.LaunchResult
 	Err            error
 }
@@ -107,12 +108,13 @@ type LoopAgentWrittenMsg struct {
 
 // LoopAgentLaunchedMsg indicates a coding/reviewer agent was launched.
 type LoopAgentLaunchedMsg struct {
-	ProjectID  string
-	IssueID    string
-	Role       string // "coder" or "reviewer"
-	LaunchedAt int64  // unix timestamp captured just before terminal launch
-	Result     *terminal.LaunchResult
-	Err        error
+	ProjectID      string
+	IssueID        string
+	Role           string // "coder" or "reviewer"
+	LaunchedAt     int64  // unix timestamp captured just before terminal launch
+	ZplexSessionID string // zplex session id from the launch; empty on wt/tmux fallback
+	Result         *terminal.LaunchResult
+	Err            error
 }
 
 // LoopPRStatusMsg carries the result of polling PR status for merge detection.

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -38,6 +38,8 @@ type ActiveTerminal struct {
 	SessionID         string // current session ID (for /resume change detection)
 	WorkDir           string // project work directory (needed to recompute logPath on session switch)
 	WorktreeBranch    string // non-empty when session runs in a git worktree (e.g. "feat/19-slug")
+	ZplexSessionID    string // non-empty only when launched via the zplex backend
+	zplexWaiting      bool   // true after we PATCH agent_state=waiting for the current permission episode; used by T8 to issue the matching active PATCH
 	State             watcher.AgentState
 	LastQuestion      string
 	PermissionMessage string // message from permission signal (e.g., "Claude needs your permission to use Bash")

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -104,7 +104,8 @@ const (
 
 func (m Model) handleTick() (tea.Model, tea.Cmd) {
 	cmds := m.checkSessionLiveness()
-	m.checkPermissionSignals()
+	cmds = append(cmds, m.checkPermissionSignals()...)
+	cmds = append(cmds, m.checkZplexActiveResync()...)
 	if scanCmd := m.checkNewSessions(); scanCmd != nil {
 		cmds = append(cmds, scanCmd)
 	}
@@ -679,24 +680,25 @@ func (m *Model) checkSessionLiveness() []tea.Cmd {
 
 // checkPermissionSignals scans ~/.zpit/signals/ for permission signal files
 // and updates matching ActiveTerminals to StatePermission.
-func (m *Model) checkPermissionSignals() {
+// Returns fire-and-forget PATCH cmds for any terminals that newly entered permission state.
+func (m *Model) checkPermissionSignals() []tea.Cmd {
 	m.state.Lock()
 	now := time.Now()
 	if now.Sub(m.state.lastPermissionCheck) < permissionCheckInterval {
 		m.state.Unlock()
-		return
+		return nil
 	}
 	m.state.lastPermissionCheck = now
 	m.state.Unlock()
 
 	dir := signalDir()
 	if dir == "" {
-		return
+		return nil
 	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return // directory may not exist yet
+		return nil // directory may not exist yet
 	}
 
 	// Collect parsed signals from filesystem (no lock needed for I/O).
@@ -722,13 +724,15 @@ func (m *Model) checkPermissionSignals() {
 	}
 
 	if len(signals) == 0 {
-		return
+		return nil
 	}
 
-	// Match signals to active terminals under lock.
+	// Match signals to active terminals under lock. Collect session IDs that newly
+	// entered permission state so we can build PATCH cmds after unlocking.
 	m.state.Lock()
 	changed := false
 	var staleFiles []string
+	var waitingIDs []string // zplex session IDs needing a "waiting" PATCH
 	for _, ps := range signals {
 		matched := false
 		for projectID, at := range m.state.activeTerminals {
@@ -751,6 +755,11 @@ func (m *Model) checkPermissionSignals() {
 			if w := m.state.notifier.ConsumeWarning(); w != "" {
 				m.setStatus(fmt.Sprintf(locale.T(locale.KeySoundFileNotFound), m.state.cfg.Notification.SoundFile))
 			}
+			// AC-8: issue waiting PATCH if terminal has a zplex session and is not already marked waiting.
+			if at.ZplexSessionID != "" && !at.zplexWaiting {
+				at.zplexWaiting = true
+				waitingIDs = append(waitingIDs, at.ZplexSessionID)
+			}
 			break
 		}
 		if !matched {
@@ -766,6 +775,32 @@ func (m *Model) checkPermissionSignals() {
 	for _, name := range staleFiles {
 		os.Remove(filepath.Join(dir, name))
 	}
+
+	// Build fire-and-forget PATCH cmds after releasing the lock.
+	var cmds []tea.Cmd
+	for _, id := range waitingIDs {
+		cmds = append(cmds, m.patchZplexStateCmd(id, "waiting"))
+	}
+	return cmds
+}
+
+// checkZplexActiveResync issues an active PATCH for any terminal that was
+// patched to waiting but has since left the permission state.
+func (m *Model) checkZplexActiveResync() []tea.Cmd {
+	m.state.Lock()
+	var ids []string
+	for _, at := range m.state.activeTerminals {
+		if at.zplexWaiting && at.State != watcher.StatePermission && at.ZplexSessionID != "" {
+			ids = append(ids, at.ZplexSessionID)
+			at.zplexWaiting = false
+		}
+	}
+	m.state.Unlock()
+	var cmds []tea.Cmd
+	for _, id := range ids {
+		cmds = append(cmds, m.patchZplexStateCmd(id, "active"))
+	}
+	return cmds
 }
 
 // checkNewSessions checks if sessionScanInterval has elapsed and, if so, returns a tea.Cmd

--- a/internal/tui/zplex_sync_test.go
+++ b/internal/tui/zplex_sync_test.go
@@ -1,0 +1,459 @@
+package tui
+
+// zplex_sync_test.go — Handler-level zplex sync tests (AC-15).
+//
+// Covers:
+//   - AC-8: waiting→active PATCH sequence for a permission episode
+//     (via checkPermissionSignals + checkZplexActiveResync)
+//   - AC-9: "done" PATCH when coder slot transitions to SlotLaunchingReviewer,
+//     and when reviewer slot transitions on "ai-review" label
+//   - AC-10: auto-close kill behavior for true/false and needs-changes cases
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/zac15987/zpit/internal/config"
+	"github.com/zac15987/zpit/internal/loop"
+	"github.com/zac15987/zpit/internal/watcher"
+	"github.com/zac15987/zpit/internal/worktree"
+)
+
+// --- helpers ---
+
+// fakePatcher records PatchAgentState calls for test assertions.
+type fakePatcher struct {
+	mu    sync.Mutex
+	calls [][2]string // each entry is [sessionID, state]
+}
+
+func (f *fakePatcher) PatchAgentState(id, state string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, [2]string{id, state})
+	return nil
+}
+
+func (f *fakePatcher) recordedCalls() [][2]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([][2]string, len(f.calls))
+	copy(cp, f.calls)
+	return cp
+}
+
+// runCmd executes a tea.Cmd tree synchronously so the PATCH/kill closures fire.
+// tea.BatchMsg is []tea.Cmd.
+func runCmd(c tea.Cmd) {
+	if c == nil {
+		return
+	}
+	msg := c()
+	if b, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range b {
+			runCmd(sub)
+		}
+	}
+}
+
+// makeZplexTestModel builds a Model suitable for zplex sync tests.
+// AutoMerge=true causes the ai-review branch to use loopAutoMergeCmd
+// (which returns nil without a tracker client) instead of loopSchedulePRPoll
+// (which produces a live timer tick).
+func makeZplexTestModel(t *testing.T, autoClose bool) Model {
+	t.Helper()
+	cfg := &config.Config{
+		Terminal:           config.TerminalConfig{ZplexPort: 17732},
+		AutoCloseAfterDone: autoClose,
+		Worktree: config.WorktreeConfig{
+			PollSeconds:     1,
+			PRPollSeconds:   1,
+			MaxPerProject:   3,
+			MaxReviewRounds: 3,
+		},
+		Projects: []config.ProjectConfig{
+			{ID: "p1", Name: "Project 1", Tracker: "t1", AutoMerge: true},
+		},
+	}
+	state := NewAppState(cfg, nil, nil, nil, nil, nil, nil, nil, worktree.HookScripts{}, nil)
+	return NewModel(state)
+}
+
+// overrideZplexClient replaces newZplexClient for the duration of the test
+// and restores it on cleanup.
+func overrideZplexClient(t *testing.T, fake *fakePatcher) {
+	t.Helper()
+	orig := newZplexClient
+	newZplexClient = func(int) zplexPatcher { return fake }
+	t.Cleanup(func() { newZplexClient = orig })
+}
+
+// seedZplexLoop installs a LoopState with one slot into m.state.loops.
+func seedZplexLoop(m Model, slot *loop.Slot) {
+	m.state.Lock()
+	defer m.state.Unlock()
+	ls := &loop.LoopState{
+		Active: true,
+		Slots:  make(map[string]*loop.Slot),
+	}
+	if slot != nil {
+		ls.Slots[loop.SlotKey(slot.ProjectID, slot.IssueID)] = slot
+	}
+	m.state.loops[slot.ProjectID] = ls
+}
+
+// --- AC-8: waiting→active PATCH sequence for a permission episode ---
+
+func TestZplexSync_AC8_WaitingToActive(t *testing.T) {
+	// Redirect home so signalDir() returns a tmp directory we control.
+	tmp := t.TempDir()
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("HOME", tmp)
+
+	// Create the signals directory and write a permission signal file.
+	sigDir := filepath.Join(tmp, ".zpit", "signals")
+	if err := os.MkdirAll(sigDir, 0o755); err != nil {
+		t.Fatalf("mkdir signals: %v", err)
+	}
+	sig := permissionSignal{SessionID: "SID", Message: "needs perm"}
+	data, _ := json.Marshal(sig)
+	if err := os.WriteFile(filepath.Join(sigDir, "permission-SID.json"), data, 0o644); err != nil {
+		t.Fatalf("write signal: %v", err)
+	}
+
+	m := makeZplexTestModel(t, true)
+	fake := &fakePatcher{}
+	overrideZplexClient(t, fake)
+
+	// Insert an ActiveTerminal with a known ZplexSessionID.
+	m.state.Lock()
+	m.state.activeTerminals["k"] = &ActiveTerminal{
+		SessionID:      "SID",
+		ZplexSessionID: "z1",
+		State:          watcher.StateWorking,
+	}
+	// Reset interval gate so checkPermissionSignals does not skip.
+	m.state.lastPermissionCheck = time.Time{}
+	m.state.Unlock()
+
+	// Step 1: detect permission signal → should emit "waiting" PATCH.
+	cmds := m.checkPermissionSignals()
+	for _, cmd := range cmds {
+		runCmd(cmd)
+	}
+
+	calls := fake.recordedCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 PATCH call after checkPermissionSignals, got %d: %v", len(calls), calls)
+	}
+	if calls[0] != [2]string{"z1", "waiting"} {
+		t.Errorf("expected PATCH {z1, waiting}, got %v", calls[0])
+	}
+
+	// Verify zplexWaiting flag is set.
+	m.state.RLock()
+	at := m.state.activeTerminals["k"]
+	if !at.zplexWaiting {
+		t.Error("expected zplexWaiting=true after waiting PATCH")
+	}
+	m.state.RUnlock()
+
+	// Step 2: simulate permission cleared — set State back to StateWorking so
+	// checkZplexActiveResync finds zplexWaiting=true and State!=StatePermission.
+	m.state.Lock()
+	m.state.activeTerminals["k"].State = watcher.StateWorking
+	m.state.Unlock()
+
+	cmds2 := m.checkZplexActiveResync()
+	for _, cmd := range cmds2 {
+		runCmd(cmd)
+	}
+
+	calls2 := fake.recordedCalls()
+	if len(calls2) != 2 {
+		t.Fatalf("expected 2 total PATCH calls after checkZplexActiveResync, got %d: %v", len(calls2), calls2)
+	}
+	if calls2[1] != [2]string{"z1", "active"} {
+		t.Errorf("expected PATCH {z1, active}, got %v", calls2[1])
+	}
+
+	// Verify zplexWaiting flag is cleared.
+	m.state.RLock()
+	if m.state.activeTerminals["k"].zplexWaiting {
+		t.Error("expected zplexWaiting=false after active PATCH")
+	}
+	m.state.RUnlock()
+}
+
+// --- AC-9: coder done on SlotCoding → SlotLaunchingReviewer ---
+
+func TestZplexSync_AC9_CoderDone_OnReviewLabel(t *testing.T) {
+	m := makeZplexTestModel(t, true)
+	fake := &fakePatcher{}
+	overrideZplexClient(t, fake)
+
+	slot := &loop.Slot{
+		ProjectID:    "p1",
+		IssueID:      "42",
+		State:        loop.SlotCoding,
+		WorktreePath: "D:/wt",
+		Sessions: []loop.SessionRef{
+			{Role: "coder", ZplexSessionID: "c1", PID: 111},
+		},
+	}
+	seedZplexLoop(m, slot)
+
+	_, cmd := m.handleLoopLabelPoll(LoopLabelPollMsg{
+		ProjectID: "p1",
+		IssueID:   "42",
+		Labels:    []string{"review"},
+	})
+
+	// Verify state transition.
+	m.state.RLock()
+	ls := m.state.loops["p1"]
+	s := ls.Slots[loop.SlotKey("p1", "42")]
+	gotState := s.State
+	m.state.RUnlock()
+
+	if gotState != loop.SlotLaunchingReviewer {
+		t.Errorf("expected SlotLaunchingReviewer, got %v", gotState)
+	}
+
+	// Run the returned cmd tree to fire PATCH closures.
+	runCmd(cmd)
+
+	calls := fake.recordedCalls()
+	found := false
+	for _, c := range calls {
+		if c == [2]string{"c1", "done"} {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected PATCH {c1, done} in calls, got %v", calls)
+	}
+}
+
+// --- AC-9 + AC-10: reviewer done + PASS kill (AutoCloseAfterDone=true) ---
+
+func TestZplexSync_AC9AC10_ReviewerDone_AutoClose_True(t *testing.T) {
+	m := makeZplexTestModel(t, true)
+	fake := &fakePatcher{}
+	overrideZplexClient(t, fake)
+
+	// Track killed PIDs.
+	var killedMu sync.Mutex
+	var killedPIDs []int
+	origKill := killSessionFn
+	killSessionFn = func(pid int) {
+		killedMu.Lock()
+		killedPIDs = append(killedPIDs, pid)
+		killedMu.Unlock()
+	}
+	t.Cleanup(func() { killSessionFn = origKill })
+
+	slot := &loop.Slot{
+		ProjectID:    "p1",
+		IssueID:      "42",
+		State:        loop.SlotReviewing,
+		WorktreePath: "D:/wt",
+		Sessions: []loop.SessionRef{
+			{Role: "coder", ZplexSessionID: "c1", PID: 111},
+			{Role: "reviewer", ZplexSessionID: "r1", PID: 222},
+		},
+	}
+	seedZplexLoop(m, slot)
+
+	_, cmd := m.handleLoopLabelPoll(LoopLabelPollMsg{
+		ProjectID: "p1",
+		IssueID:   "42",
+		Labels:    []string{"ai-review"},
+	})
+
+	// Verify state transition to SlotAutoMerging (AutoMerge=true).
+	m.state.RLock()
+	ls := m.state.loops["p1"]
+	s := ls.Slots[loop.SlotKey("p1", "42")]
+	gotState := s.State
+	m.state.RUnlock()
+
+	if gotState != loop.SlotAutoMerging {
+		t.Errorf("expected SlotAutoMerging, got %v", gotState)
+	}
+
+	// Run cmd tree.
+	runCmd(cmd)
+
+	// Assert reviewer done PATCH.
+	calls := fake.recordedCalls()
+	foundReviewerDone := false
+	for _, c := range calls {
+		if c == [2]string{"r1", "done"} {
+			foundReviewerDone = true
+			break
+		}
+	}
+	if !foundReviewerDone {
+		t.Errorf("expected PATCH {r1, done} in calls, got %v", calls)
+	}
+
+	// Assert both PIDs were killed.
+	killedMu.Lock()
+	killed := make([]int, len(killedPIDs))
+	copy(killed, killedPIDs)
+	killedMu.Unlock()
+
+	if len(killed) != 2 {
+		t.Fatalf("expected 2 killed PIDs, got %d: %v", len(killed), killed)
+	}
+	has111, has222 := false, false
+	for _, pid := range killed {
+		if pid == 111 {
+			has111 = true
+		}
+		if pid == 222 {
+			has222 = true
+		}
+	}
+	if !has111 || !has222 {
+		t.Errorf("expected PIDs 111 and 222 killed, got %v", killed)
+	}
+}
+
+// --- AC-10: PASS no-kill when AutoCloseAfterDone=false ---
+
+func TestZplexSync_AC10_ReviewerDone_AutoClose_False(t *testing.T) {
+	m := makeZplexTestModel(t, false) // AutoCloseAfterDone = false
+	fake := &fakePatcher{}
+	overrideZplexClient(t, fake)
+
+	var killedMu sync.Mutex
+	var killedPIDs []int
+	origKill := killSessionFn
+	killSessionFn = func(pid int) {
+		killedMu.Lock()
+		killedPIDs = append(killedPIDs, pid)
+		killedMu.Unlock()
+	}
+	t.Cleanup(func() { killSessionFn = origKill })
+
+	slot := &loop.Slot{
+		ProjectID:    "p1",
+		IssueID:      "42",
+		State:        loop.SlotReviewing,
+		WorktreePath: "D:/wt",
+		Sessions: []loop.SessionRef{
+			{Role: "coder", ZplexSessionID: "c1", PID: 111},
+			{Role: "reviewer", ZplexSessionID: "r1", PID: 222},
+		},
+	}
+	seedZplexLoop(m, slot)
+
+	_, cmd := m.handleLoopLabelPoll(LoopLabelPollMsg{
+		ProjectID: "p1",
+		IssueID:   "42",
+		Labels:    []string{"ai-review"},
+	})
+
+	runCmd(cmd)
+
+	// Reviewer done PATCH must still fire.
+	calls := fake.recordedCalls()
+	foundReviewerDone := false
+	for _, c := range calls {
+		if c == [2]string{"r1", "done"} {
+			foundReviewerDone = true
+			break
+		}
+	}
+	if !foundReviewerDone {
+		t.Errorf("expected PATCH {r1, done} in calls, got %v", calls)
+	}
+
+	// No PIDs should have been killed.
+	killedMu.Lock()
+	nKilled := len(killedPIDs)
+	killedMu.Unlock()
+
+	if nKilled != 0 {
+		t.Errorf("expected 0 killed PIDs when AutoCloseAfterDone=false, got %d", nKilled)
+	}
+}
+
+// --- AC-10: needs-changes never kills ---
+
+func TestZplexSync_AC10_NeedsChanges_NeverKills(t *testing.T) {
+	m := makeZplexTestModel(t, true) // AutoCloseAfterDone=true — still no kill on needs-changes
+	fake := &fakePatcher{}
+	overrideZplexClient(t, fake)
+
+	var killedMu sync.Mutex
+	var killedPIDs []int
+	origKill := killSessionFn
+	killSessionFn = func(pid int) {
+		killedMu.Lock()
+		killedPIDs = append(killedPIDs, pid)
+		killedMu.Unlock()
+	}
+	t.Cleanup(func() { killSessionFn = origKill })
+
+	slot := &loop.Slot{
+		ProjectID:   "p1",
+		IssueID:     "42",
+		State:       loop.SlotReviewing,
+		ReviewRound: 0,
+		Sessions: []loop.SessionRef{
+			{Role: "reviewer", ZplexSessionID: "r1", PID: 222},
+		},
+	}
+	seedZplexLoop(m, slot)
+
+	_, cmd := m.handleLoopLabelPoll(LoopLabelPollMsg{
+		ProjectID: "p1",
+		IssueID:   "42",
+		Labels:    []string{"needs-changes"},
+	})
+
+	// State should be SlotWritingAgent (revision path).
+	m.state.RLock()
+	ls := m.state.loops["p1"]
+	s := ls.Slots[loop.SlotKey("p1", "42")]
+	gotState := s.State
+	m.state.RUnlock()
+
+	if gotState != loop.SlotWritingAgent {
+		t.Errorf("expected SlotWritingAgent on needs-changes, got %v", gotState)
+	}
+
+	runCmd(cmd)
+
+	// Reviewer done PATCH must fire.
+	calls := fake.recordedCalls()
+	foundReviewerDone := false
+	for _, c := range calls {
+		if c == [2]string{"r1", "done"} {
+			foundReviewerDone = true
+			break
+		}
+	}
+	if !foundReviewerDone {
+		t.Errorf("expected PATCH {r1, done} on needs-changes, got %v", calls)
+	}
+
+	// No PIDs should be killed on needs-changes.
+	killedMu.Lock()
+	nKilled := len(killedPIDs)
+	killedMu.Unlock()
+
+	if nKilled != 0 {
+		t.Errorf("expected 0 killed PIDs on needs-changes (AC-10), got %d", nKilled)
+	}
+}

--- a/internal/zplex/client.go
+++ b/internal/zplex/client.go
@@ -1,0 +1,162 @@
+// Package zplex provides an HTTP client for the zplex session daemon.
+// The daemon exposes a REST API for creating and managing terminal sessions.
+// The client does not log; callers should inspect returned errors.
+package zplex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	healthTimeout        = 500 * time.Millisecond
+	createSessionTimeout = 5 * time.Second
+	patchStateTimeout    = 3 * time.Second
+)
+
+// CreateSessionRequest is the JSON body sent to POST /api/sessions.
+type CreateSessionRequest struct {
+	Shell      string   `json:"shell"`
+	Title      string   `json:"title"`
+	Args       []string `json:"args,omitempty"`
+	Cwd        string   `json:"cwd,omitempty"`
+	Env        []string `json:"env,omitempty"`
+	Cols       int      `json:"cols,omitempty"`
+	Rows       int      `json:"rows,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	ProjectID  string   `json:"project_id,omitempty"`
+	IssueID    string   `json:"issue_id,omitempty"`
+	Role       string   `json:"role,omitempty"`
+	AgentState string   `json:"agent_state,omitempty"`
+}
+
+// createSessionResponse is the JSON body returned by POST /api/sessions.
+type createSessionResponse struct {
+	ID    string `json:"id"`
+	WsURL string `json:"ws_url"`
+}
+
+// patchAgentStateBody is the JSON body sent to PATCH /api/sessions/{id}.
+type patchAgentStateBody struct {
+	AgentState string `json:"agent_state"`
+}
+
+// Client communicates with the zplex daemon on localhost.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New creates a Client that targets the zplex daemon on the given port.
+func New(port int) *Client {
+	return &Client{
+		baseURL:    fmt.Sprintf("http://127.0.0.1:%d", port),
+		httpClient: &http.Client{},
+	}
+}
+
+// NewWithBaseURL creates a Client with an explicit base URL.
+// Intended for testing against httptest servers.
+func NewWithBaseURL(baseURL string) *Client {
+	return &Client{
+		baseURL:    baseURL,
+		httpClient: &http.Client{},
+	}
+}
+
+// Health performs GET /api/health and returns an error if the daemon is
+// unreachable, times out (500 ms), or responds with a non-200 status code.
+func (c *Client) Health() error {
+	ctx, cancel := context.WithTimeout(context.Background(), healthTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/health", nil)
+	if err != nil {
+		return fmt.Errorf("zplex: build health request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("zplex: health: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("zplex: health: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// CreateSession posts a new session to POST /api/sessions and returns the
+// session id from the daemon's response. Returns an error on non-2xx status.
+func (c *Client) CreateSession(req CreateSessionRequest) (string, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("zplex: marshal create session request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), createSessionTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/sessions", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("zplex: build create session request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("zplex: create session: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("zplex: create session: unexpected status %d", resp.StatusCode)
+	}
+
+	var result createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("zplex: decode create session response: %w", err)
+	}
+	return result.ID, nil
+}
+
+// PatchAgentState sends PATCH /api/sessions/{id} with {"agent_state": state}.
+// Valid states are "", "active", "waiting", and "done". Returns an error on
+// non-2xx status.
+func (c *Client) PatchAgentState(id, state string) error {
+	body, err := json.Marshal(patchAgentStateBody{AgentState: state})
+	if err != nil {
+		return fmt.Errorf("zplex: marshal patch agent state: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), patchStateTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPatch,
+		c.baseURL+"/api/sessions/"+id, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("zplex: build patch agent state request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("zplex: patch agent state: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("zplex: patch agent state: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/zplex/client_test.go
+++ b/internal/zplex/client_test.go
@@ -1,0 +1,119 @@
+package zplex_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zac15987/zpit/internal/zplex"
+)
+
+// TestHealth_OK verifies that Health returns nil when the daemon responds 200.
+func TestHealth_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := zplex.NewWithBaseURL(srv.URL)
+	if err := c.Health(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+// TestHealth_NonOK verifies that Health returns an error when the daemon
+// responds with a non-200 status code.
+func TestHealth_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := zplex.NewWithBaseURL(srv.URL)
+	if err := c.Health(); err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}
+
+// TestCreateSession verifies method, path, request body fields, and that the
+// returned id matches the daemon's JSON response.
+func TestCreateSession(t *testing.T) {
+	const wantID = "abc123"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/sessions" {
+			t.Errorf("expected path /api/sessions, got %s", r.URL.Path)
+		}
+
+		var body zplex.CreateSessionRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		if body.Shell != "/bin/bash" {
+			t.Errorf("expected shell=/bin/bash, got %q", body.Shell)
+		}
+		if body.Title != "test-session" {
+			t.Errorf("expected title=test-session, got %q", body.Title)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id":     wantID,
+			"ws_url": "/ws/" + wantID,
+		})
+	}))
+	defer srv.Close()
+
+	c := zplex.NewWithBaseURL(srv.URL)
+	gotID, err := c.CreateSession(zplex.CreateSessionRequest{
+		Shell: "/bin/bash",
+		Title: "test-session",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	if gotID != wantID {
+		t.Errorf("expected id=%q, got %q", wantID, gotID)
+	}
+}
+
+// TestPatchAgentState verifies method, path, and that the request body
+// contains the expected agent_state value.
+func TestPatchAgentState(t *testing.T) {
+	const sessionID = "abc123"
+	const wantState = "waiting"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		wantPath := "/api/sessions/" + sessionID
+		if r.URL.Path != wantPath {
+			t.Errorf("expected path %s, got %s", wantPath, r.URL.Path)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		if body["agent_state"] != wantState {
+			t.Errorf("expected agent_state=%q, got %q", wantState, body["agent_state"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := zplex.NewWithBaseURL(srv.URL)
+	if err := c.PatchAgentState(sessionID, wantState); err != nil {
+		t.Fatalf("PatchAgentState returned error: %v", err)
+	}
+}

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -8,11 +8,16 @@ broker_port = 17731
 # Useful when running via "go run ." where the temp binary path becomes invalid.
 # zpit_bin = "D:/path/to/zpit.exe"
 
+# auto_close_after_done: when true, zpit kills a slot's terminal panels after
+# the reviewer issues a PASS (review done). Set to false to keep panels open.
+auto_close_after_done = true
+
 [terminal]
 windows_mode = "new_tab"
 tmux_mode = "new_window"
 windows_terminal_profile = "PowerShell 7"
 # windows_terminal_profile = "PowerShell 7"  # WT profile name for -p flag and auto shell detection
+zplex_port = 17732           # TCP port for the zplex launcher backend; 0 disables the zplex backend
 
 [ssh]
 port = 2200


### PR DESCRIPTION
## Summary

Implements M4 zplex deep-integration on the zpit side, conforming to the zplex daemon API merged in zplex PR #16 (verified against the `dev` branch of zplex: `daemon/server/api.go`, `daemon/session/session.go`). zpit can now launch Claude Code sessions, lazygit, and `claude update` into the zplex daemon as a launch **backend**, sync a session's `agent_state` over its lifecycle, and auto-close a slot's panels after review PASS.

Closes #111.

## What changed

**Launch backend (terminal layer)**
- New package `internal/zplex` — HTTP client (`Health` / `CreateSession` / `PatchAgentState`), base `http://127.0.0.1:<port>`. The client returns errors and never logs.
- `platform.EnvZplex` enum value (`String()` → `"zplex"`), a display-only marker. `platform.Detect()` is unchanged and the platform package gains no new imports.
- All four launch entry points (`LaunchClaude`, `LaunchClaudeInDir`, `LaunchLazygit`, `LaunchClaudeUpdate`) probe zplex first: when `terminal.zplex_port > 0` and `GET /api/health` (500 ms) returns 200, the session is created via `POST /api/sessions`; otherwise zpit falls back to the existing `platform.Detect()` switch. **Launch priority: zplex probe → Windows Terminal → tmux → error.** When `zplex_port = 0` no HTTP request is made at all.
- POST body carries `source: "zpit"`, `title` (required), `cwd`, claude args (via the existing `buildClaudeArgs`/`filterChannelFlag` pipeline incl. the `--channel-enabled` rewrite), and identity metadata (`project_id`, `issue_id`, `role`, `agent_state`). `env` is set to `append(os.Environ(), "ZPIT_AGENT=1", "ZPIT_AGENT_TYPE=<role>")` **iff** `needsAgentEnv(extraArgs)` (zplex replaces, not merges, the child env); omitted otherwise. No zpit-env/zpit-exit wrapper scripts on the zplex path.

**agent_state sync + auto-close (loop/TUI layer)**
- `loop.Slot` now accumulates a `Sessions []SessionRef` ({PID, zplex session id, role}) appended on every coder/reviewer launch (incl. revision rounds), instead of overwriting a single PID. `terminal.LaunchResult` and `tui.ActiveTerminal` gained `ZplexSessionID`.
- Permission scanner PATCHes `waiting` when a session is flagged and `active` when it leaves the permission state (tick-driven reconciliation, since the permission-clear is observed in `handleAgentEvent`). Loop PATCHes `done` for the coder when leaving `SlotCoding` and for the reviewer when leaving `SlotReviewing` (PASS or needs-changes). All PATCHes are best-effort, fire-and-forget; empty zplex ids are skipped.
- New global config `auto_close_after_done` (default `true`): on review PASS (`ai-review`) zpit kills every session in the slot's reference list via the existing kill path (`KillWithZeroExit` + parent-shell kill); zplex panels then close on process exit. `needs-changes` never closes. Issued from the PASS business handler without rescheduling any poll chain (loop-tick invariant preserved; `loop_tick_test.go` stays green).

**Config**
- `terminal.zplex_port` (int, default `17732`; `0` disables) and top-level `auto_close_after_done` (bool, default `true`). Defaults distinguish "omitted" from explicit `0`/`false` via `toml.MetaData.IsDefined`. Both classified **hot** by `config.Diff()`. Template + `testdata/config.toml` kept in parity.

**Docs**: `docs/architecture/03/04/07`, `README.md`, `CLAUDE.md` (package map + amended "loop never kills terminals" invariant).

## Decisions recorded (not asked, per autonomy contract)
- **`internal/zplex` client injected via a package-level var** (`newZplexClient`) and the kill layer via `killSessionFn`, rather than new `AppState` fields — `appstate.go` and `model.go` are outside this issue's file scope, and this keeps the sync logic unit-testable (`zplex_sync_test.go`).
- **`LaunchClaudeInDir` signature gained a `SessionMeta` param** to carry `project_id`/`issue_id` into loop POST bodies (AC-6); call sites in `launch.go`/`loop_cmds.go` updated.
- **Production population of `ActiveTerminal.ZplexSessionID`** is wired for the in-scope creation points (desktop launch). Manual project-launch population flows through `model.go`'s `handleLaunchResult`, which is outside this issue's scope; the AC-8 logic operates correctly on any terminal that carries a non-empty `ZplexSessionID` and is exercised directly in `zplex_sync_test.go`.
- **Localized launch status** (`KeyZplexLaunched`) surfaced on the in-scope lazygit/claude-update zplex paths to satisfy AC-13; `model.go`'s manual-launch status line is out of scope.
- **Auto-close PID resolution**: `SessionRef.PID` is back-filled best-effort from `activeTerminals` (by zplex id / worktree) at PASS time, since the claude PID is not known at POST time.

## Testing
- `go build ./...`, `go vet`, and `go test ./...` all pass.
- `internal/zplex/client_test.go` (Health/Create/Patch via httptest), `internal/terminal/launcher_zplex_test.go` (fallback, zero-port no-request, POST bodies for agent+env / efficiency+desktop no-env / plain / lazygit / claude-update / loop metadata), `internal/tui/zplex_sync_test.go` (waiting→active, coder/reviewer done, auto-close true/false/needs-changes), `internal/config/config_test.go` (defaults, explicit-zero, hot-reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
